### PR TITLE
Simple Job system

### DIFF
--- a/Hive/CMakeLists.txt
+++ b/Hive/CMakeLists.txt
@@ -12,10 +12,10 @@ add_library(HiveCore SHARED
         Core/Platform/Platform_Windows.cpp
         Core/Profiling/Profiler.cpp
         Core/Timing/RateController.cpp
+        Core/Concurrency/JobSystem.cpp
+
         Graphic/GFX.cpp
-
         Display/DisplayAPI.cpp
-
 
         hive.cpp
 )

--- a/Hive/Core/Concurrency/JobSystem.cpp
+++ b/Hive/Core/Concurrency/JobSystem.cpp
@@ -6,6 +6,7 @@
 
 namespace hive {
 	JobSystem::JobSystem() {
+		// Leaves two threads, one for the main program and one for the operating system
 		const unsigned int num_threads = std::max(1U, std::thread::hardware_concurrency() -2U);
 		HIVE_LOG_INFO("Creating %i worker threads", num_threads);
 

--- a/Hive/Core/Concurrency/JobSystem.cpp
+++ b/Hive/Core/Concurrency/JobSystem.cpp
@@ -1,0 +1,70 @@
+//
+// Created by wstap on 2025-07-27.
+//
+
+#include "JobSystem.h"
+
+namespace hive {
+	JobSystem::JobSystem() {
+		const unsigned int num_threads = std::max(1U, std::thread::hardware_concurrency() -2U);
+		HIVE_LOG_INFO("Creating %i worker threads", num_threads);
+
+		m_threads.reserve(num_threads);
+		for (unsigned int i = 0; i < num_threads; ++i) {
+			m_threads.emplace_back(&JobSystem::worker, this);
+		}
+	}
+
+	JobSystem::~JobSystem() {
+		HIVE_LOG_INFO("Shutting down job system and joining threads.");
+		std::unique_lock lock(m_queueMutex);
+		m_shouldStop = true;
+		m_condition.notify_all();
+
+		for (auto& thread : m_threads) {
+			if (thread.joinable()) {
+				thread.join();
+			}
+		}
+	}
+
+	void JobSystem::schedule(std::function<void()> job)
+	{
+		auto job_wrapper = std::make_unique<LambdaJob>(std::move(job));
+		schedule(std::move(job_wrapper));
+	}
+
+	void JobSystem::schedule(std::unique_ptr<IJob> job)
+	{
+		{
+			std::unique_lock lock(m_queueMutex);
+			m_jobQueue.push_back(std::move(job));
+		}
+		m_condition.notify_one();
+	}
+
+	void JobSystem::worker()
+	{
+		while(true) {
+			std::unique_ptr<IJob> job;
+			{
+				std::unique_lock lock(m_queueMutex);
+
+				m_condition.wait(lock, [this]
+				{
+					return m_shouldStop || !m_jobQueue.empty();
+				});
+
+				if (m_shouldStop) return;
+
+				job = std::move(m_jobQueue.front());
+				m_jobQueue.pop_front();
+			}
+
+			if (job) {
+				(*job)();
+			}
+
+		}
+	}
+} // hive

--- a/Hive/Core/Concurrency/JobSystem.cpp
+++ b/Hive/Core/Concurrency/JobSystem.cpp
@@ -1,7 +1,3 @@
-//
-// Created by wstap on 2025-07-27.
-//
-
 #include "JobSystem.h"
 
 namespace hive {
@@ -18,9 +14,11 @@ namespace hive {
 
 	JobSystem::~JobSystem() {
 		HIVE_LOG_INFO("Shutting down job system and joining threads.");
-		std::unique_lock lock(m_queueMutex);
-		m_shouldStop = true;
-		m_condition.notify_all();
+		{
+			std::unique_lock lock(m_queueMutex);
+			m_shouldStop = true;
+			m_condition.notify_all();
+		}
 
 		for (auto& thread : m_threads) {
 			if (thread.joinable()) {

--- a/Hive/Core/Concurrency/JobSystem.h
+++ b/Hive/Core/Concurrency/JobSystem.h
@@ -1,7 +1,3 @@
-//
-// Created by wstap on 2025-07-27.
-//
-
 #pragma once
 #include <thread>
 #include <utility>
@@ -11,7 +7,12 @@
 namespace hive {
     class HIVE_API IJob {
     public:
+        IJob() = default;
         virtual ~IJob() = default;
+
+        IJob(const IJob&) = delete;
+        IJob& operator=(const IJob&) = delete;
+
         virtual void operator()() const = 0;
     };
 

--- a/Hive/Core/Concurrency/JobSystem.h
+++ b/Hive/Core/Concurrency/JobSystem.h
@@ -1,0 +1,46 @@
+//
+// Created by wstap on 2025-07-27.
+//
+
+#pragma once
+#include <thread>
+#include <utility>
+#include <mutex>
+#include <condition_variable>
+
+namespace hive {
+    class HIVE_API IJob {
+    public:
+        virtual ~IJob() = default;
+        virtual void operator()() const = 0;
+    };
+
+    class HIVE_API JobSystem {
+    public:
+        JobSystem();
+        ~JobSystem();
+
+        void schedule(std::function<void()> job);
+        void schedule(std::unique_ptr<IJob> job);
+
+    private:
+        void worker();
+
+        std::vector<std::thread> m_threads;
+
+        std::deque<std::unique_ptr<IJob>> m_jobQueue;
+        std::mutex m_queueMutex;
+        std::condition_variable m_condition;
+        bool m_shouldStop = false;
+
+        class LambdaJob : public IJob
+        {
+        public:
+            LambdaJob(std::function<void()> lambda): m_lambda(std::move(lambda)) {}
+            void operator()() const override { m_lambda(); }
+        private:
+            std::function<void()> m_lambda;
+        };
+    };
+
+} // hive

--- a/Hive/Core/Timing/RateController.h
+++ b/Hive/Core/Timing/RateController.h
@@ -7,7 +7,7 @@ namespace hive {
 	public:
 
 		RateController(int targetRate)
-			: frameDuration(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(1000.0 / targetRate))),
+			: frameDuration(1000/targetRate),
 			lastUpdateTime(std::chrono::high_resolution_clock::now())
 		{}
 

--- a/Hive/hvpch.h
+++ b/Hive/hvpch.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <string>
 #include <vector>
@@ -7,6 +8,7 @@
 #include <memory>
 #include <unordered_map>
 #include <queue>
+#include <deque>
 
 
 using uint8 = uint8_t;

--- a/Testbed/CMakeLists.txt
+++ b/Testbed/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_executable(Testbed main.cpp)
+add_executable(Testbed main.cpp
+        JobExample/Job.h
+)
 target_link_libraries(Testbed PRIVATE HiveCore)
 
 if(WIN32)

--- a/Testbed/JobExample/Job.h
+++ b/Testbed/JobExample/Job.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <iostream>
+#include "Core/Concurrency/JobSystem.h"
+
+namespace hive {
+
+    class PrintMessageJob : public IJob
+    {
+        int id;
+        char* name;
+
+    public:
+        PrintMessageJob(int id, char *name)
+            : id(id), name(name) {}
+
+        void operator()() const override
+        {
+            std::cout << "JobDemo: " << id << " - " << name << std::endl;
+        }
+    };
+
+    class CountJob : public IJob
+    {
+        int start, end;
+
+    public:
+        CountJob(int start, int end)
+            : start(start), end(end) {}
+
+        void operator()() const override
+        {
+            int j = 1;
+            for(int i = start; i < end; i++) {
+                j*= i;
+            }
+            std::cout << j << "Count job done with start=" << start << std::endl;
+        }
+    };
+
+} // hive

--- a/Testbed/main.cpp
+++ b/Testbed/main.cpp
@@ -19,6 +19,7 @@
 #include <Core/Timing/RateController.h>
 
 #include "tiny_obj_loader.h"
+#include "JobExample/Job.h"
 
 
 constexpr int MAX_FRAME_IN_FLIGHT = 3;
@@ -68,7 +69,10 @@ struct VikingScene
 
 Testbed testbed;
 VikingScene scene;
+
 hive::RateController rateController(30);
+
+
 
 void InitDisplay(hive::EventManager &event_manager);
 void InitGraphic();
@@ -102,9 +106,26 @@ int main()
         application_run = false;
     });
 
+
+    hive::JobSystem jobSystem;
+
+    for(int i = 0; i < 10000; i++) {
+        jobSystem.schedule(
+            std::make_unique<hive::CountJob>(i*10000, i*10000 + 9999)
+        );
+        jobSystem.schedule([i]()
+        {
+            int k = 1;
+            for(int j = i*10000; j < i*10000+9999; j++) {
+                k*= j;
+            }
+            std::cout << k << "Lambda job done with start=" << i*10000 << std::endl;
+        });
+    }
     HIVE_LOG_INFO("Hello World");
     int current_frame = 0;
     static auto startTime = std::chrono::high_resolution_clock::now();
+
     while(application_run)
     {
         ProfileCZoneName(ctx, "render");


### PR DESCRIPTION
Adds a simple job system that allows multithreaded computing.

The proposed solution contains :
1. A thread pool that creates the maximum amount of threads available minus one thread for the main program and one thread for the operating system.
2. A single thread-safe job queue where the thread pool will run the different tasks in it.
3. A `schedule` method that can push either classes that implements IJob or lambdas into the queue.

Solves #104 

Also fixes a bug related to the RateController freezing the window.