### PR TITLE
Integrate fmt library and add assertion utilities

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,12 @@
 [submodule "Hive/extern/glfw"]
 	path = Terra/extern/glfw
 	url = https://github.com/glfw/glfw.git
-[submodule "Testbed/extern/swarm"]
-	path = Testbed/extern/swarm
-	url = https://github.com/HiveEngine/Swarm
+[submodule "Cells/Swarm/extern/nvrhi"]
+	path = Cells/swarm/extern/nvrhi
+	url = https://github.com/NVIDIA-RTX/NVRHI.git
+[submodule "Cells/swarm/extern/vk-bootstrap"]
+	path = Cells/swarm/extern/vk-bootstrap
+	url = https://github.com/charles-lunarg/vk-bootstrap.git
+[submodule "Hive/extern/fmt"]
+	path = Hive/extern/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,281 @@
 cmake_minimum_required(VERSION 3.30.5)
-project(HiveEngine_Redo)
+
+# Workaround for CMake 3.31 introspection bug with custom Clang builds on Windows
+# Skip linking during try_compile to avoid malformed generator expressions
+if(WIN32)
+    set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+endif()
+
+# Clang on Windows needs RC compiler set before project()
+# We don't use .rc files, but CMake requires it
+if(WIN32 AND NOT CMAKE_RC_COMPILER)
+    # Try to find rc.exe from Windows SDK (installed with MSVC)
+    file(GLOB RC_PATHS
+            "C:/Program Files (x86)/Windows Kits/10/bin/*/x64/rc.exe"
+            "C:/Program Files (x86)/Windows Kits/*/bin/x64/rc.exe"
+    )
+    if(RC_PATHS)
+        list(GET RC_PATHS 0 FOUND_RC)
+        set(CMAKE_RC_COMPILER "${FOUND_RC}" CACHE FILEPATH "RC Compiler")
+    else()
+        # Fallback: hope rc.exe is in PATH
+        set(CMAKE_RC_COMPILER "rc" CACHE FILEPATH "RC Compiler")
+    endif()
+endif()
+
+project(HiveEngine_Redo LANGUAGES CXX)
+
+# ============================================================================
+# Build Configuration
+# ============================================================================
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-set(swarm_use_vulkan ON)
-set(terra_use_glfw ON)
+# Build types
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo" CACHE STRING "" FORCE)
+
+# ============================================================================
+# Engine Options
+# ============================================================================
+
+set(swarm_use_vulkan ON CACHE BOOL "Enable Vulkan GPU allocator")
+set(terra_use_glfw ON CACHE BOOL "Enable GLFW windowing")
+
+option(HIVE_ENABLE_LTO "Enable Link-Time Optimization (slower compile, better runtime)" ON)
+option(HIVE_ENABLE_FAST_MATH "Enable fast math optimizations (less precise)" OFF)
+option(HIVE_WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
+option(HIVE_ENABLE_SIMD "Enable SIMD optimizations (SSE2)" ON)
+
+# ============================================================================
+# Compiler Flags - ALL PLATFORMS
+# ============================================================================
+
+# Disable RTTI (Run-Time Type Information)
+# Saves 15-20% binary size, improves performance
+if(MSVC)
+    add_compile_options(/GR-)
+else()
+    add_compile_options(-fno-rtti)
+endif()
+
+# Disable C++ Exceptions
+# Saves 5-10% binary size, improves performance
+# WARNING: STL will call std::terminate on errors
+if(MSVC)
+    # Remove CMake's default /EHsc flag to avoid D9025 warning
+    string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    add_compile_options(/EHs-c-)
+else()
+    add_compile_options(-fno-exceptions)
+endif()
+
+# ============================================================================
+# Compiler Flags
+# ============================================================================
+
+# MSVC (not Clang-CL)
+if(MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(
+            /MP /permissive- /Zc:__cplusplus /Zc:inline /utf-8
+    )
+
+    add_compile_options(/external:W0 /external:anglebrackets)
+
+    add_compile_options(
+            /W4                  # Warning level 4
+            /w14242              # Conversion, possible loss of data
+            /w14254              # Operator conversion, possible loss of data
+            /w14263              # Member function does not override
+            /w14265              # Class has virtual functions but no virtual destructor
+            /w14287              # Unsigned/negative constant mismatch
+            /w14296              # Expression is always constant
+            /w14640              # Thread-unsafe static member initialization
+            /wd4100              # Disable: unreferenced formal parameter (too noisy)
+            /wd4530              # Disable: C++ exception handler (from external headers with /EHs-c-)
+    )
+
+    if(HIVE_WARNINGS_AS_ERRORS)
+        add_compile_options(/WX)
+    endif()
+
+    # Debug flags
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_compile_options(/Od /MDd /Zi)
+        add_compile_definitions(_DEBUG _ITERATOR_DEBUG_LEVEL=2)
+    endif()
+
+    # Release flags
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        add_compile_options(/O2 /Oi /MD /GS- /Gy)
+        add_compile_definitions(NDEBUG _ITERATOR_DEBUG_LEVEL=0)
+
+        if(HIVE_ENABLE_LTO)
+            add_compile_options(/GL)
+            add_link_options(/LTCG /OPT:REF /OPT:ICF)
+        endif()
+
+        if(HIVE_ENABLE_FAST_MATH)
+            add_compile_options(/fp:fast)
+        endif()
+    endif()
+
+    # RelWithDebInfo flags
+    if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+        add_compile_options(/O2 /Zi /MD)
+        add_compile_definitions(NDEBUG _ITERATOR_DEBUG_LEVEL=1)
+    endif()
+
+    if(HIVE_ENABLE_SIMD)
+        add_compile_options(/arch:SSE2)
+    endif()
+
+endif()
+
+# GCC/Clang
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(
+            -Wall                    # Enable most warnings
+            -Wextra                  # Extra warnings
+            -Wpedantic               # Strict ISO C++
+            -Wshadow                 # Warn if variable shadows
+            -Wnon-virtual-dtor       # Virtual functions without virtual destructor
+            -Wold-style-cast         # C-style casts
+            -Wcast-align             # Unaligned pointer casts
+            -Wunused                 # Unused variables/functions
+            -Woverloaded-virtual     # Missing override
+            -Wconversion             # Implicit type conversions
+            -Wsign-conversion        # Sign conversions
+            -Wdouble-promotion       # float->double promotions
+    )
+
+    if(HIVE_WARNINGS_AS_ERRORS)
+        add_compile_options(-Werror)
+    endif()
+
+    # Debug flags
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_compile_options(-O0 -g3)
+        add_compile_definitions(_GLIBCXX_DEBUG)
+    endif()
+
+    # Release flags
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        add_compile_options(-O3 -ffunction-sections -fdata-sections)
+
+        # Use --gc-sections only on Linux/macOS (not Windows where LLD doesn't support it)
+        if(NOT WIN32)
+            add_link_options(-Wl,--gc-sections)
+        endif()
+
+        if(HIVE_ENABLE_FAST_MATH)
+            add_compile_options(-ffast-math)
+        endif()
+    endif()
+
+    # RelWithDebInfo flags
+    if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+        add_compile_options(-O2 -g)
+    endif()
+
+    if(HIVE_ENABLE_SIMD)
+        add_compile_options(-msse2)
+    endif()
+endif()
+
+if(HIVE_ENABLE_LTO AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    # For Clang on Windows, manually enable LTO via compile flags
+    # check_ipo_supported() has issues with custom Clang builds
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND WIN32)
+        add_compile_options($<$<CONFIG:Release>:-flto=thin>)
+        add_compile_options($<$<CONFIG:RelWithDebInfo>:-flto=thin>)
+        add_link_options($<$<CONFIG:Release>:-flto=thin>)
+        add_link_options($<$<CONFIG:RelWithDebInfo>:-flto=thin>)
+        message(STATUS "✅ LTO enabled for Release builds (Clang thin LTO)")
+    else()
+        include(CheckIPOSupported)
+        check_ipo_supported(RESULT ipo_supported OUTPUT ipo_output)
+
+        if(ipo_supported)
+            set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+            set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO ON)
+            message(STATUS "✅ LTO/IPO enabled for Release builds")
+        else()
+            message(WARNING "⚠️ LTO/IPO not supported: ${ipo_output}")
+        endif()
+    endif()
+endif()
+
+# Platform detection
+if(WIN32)
+    add_compile_definitions(HIVE_PLATFORM_WINDOWS=1)
+elseif(UNIX AND NOT APPLE)
+    add_compile_definitions(HIVE_PLATFORM_LINUX=1)
+elseif(APPLE)
+    add_compile_definitions(HIVE_PLATFORM_MACOS=1)
+endif()
+
+# Build configuration-specific definitions
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_definitions(
+            HIVE_DEBUG=1
+            HIVE_ENABLE_ASSERTS=1
+            HIVE_LOG_LEVEL=0
+    )
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+    add_compile_definitions(
+            HIVE_RELEASE=1
+            HIVE_ENABLE_ASSERTS=0
+            HIVE_LOG_LEVEL=3
+    )
+elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    add_compile_definitions(
+            HIVE_RELWITHDEBINFO=1
+            HIVE_ENABLE_ASSERTS=0
+            HIVE_LOG_LEVEL=2
+    )
+endif()
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
+    string(TOUPPER ${CONFIG} CONFIG_UPPER)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${CONFIG_UPPER} ${CMAKE_BINARY_DIR}/bin/${CONFIG})
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${CONFIG_UPPER} ${CMAKE_BINARY_DIR}/lib/${CONFIG})
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${CONFIG_UPPER} ${CMAKE_BINARY_DIR}/lib/${CONFIG})
+endforeach()
 
 add_subdirectory(Hive)
-#add_subdirectory(Swarm)
 add_subdirectory(Terra)
-add_subdirectory(Testbed)
+#add_subdirectory(Testbed)
+#add_subdirectory(Cells)
+
+message(STATUS "")
+message(STATUS "====================================")
+message(STATUS "  HiveEngine Build Configuration")
+message(STATUS "====================================")
+message(STATUS "Build type:         ${CMAKE_BUILD_TYPE}")
+message(STATUS "C++ Standard:       ${CMAKE_CXX_STANDARD}")
+message(STATUS "Compiler:           ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+message(STATUS "")
+message(STATUS "Optimizations:")
+message(STATUS "  RTTI:             ❌ Disabled")
+message(STATUS "  Exceptions:       ❌ Disabled")
+message(STATUS "  LTO:              ${HIVE_ENABLE_LTO}")
+message(STATUS "  Fast Math:        ${HIVE_ENABLE_FAST_MATH}")
+message(STATUS "  SIMD:             ${HIVE_ENABLE_SIMD}")
+message(STATUS "  Warnings->Errors: ${HIVE_WARNINGS_AS_ERRORS}")
+message(STATUS "")
+message(STATUS "Engine Options:")
+message(STATUS "  Vulkan:           ${swarm_use_vulkan}")
+message(STATUS "  GLFW:             ${terra_use_glfw}")
+message(STATUS "")
+message(STATUS "Output:")
+message(STATUS "  Binaries:         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+message(STATUS "  Libraries:        ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+message(STATUS "====================================")
+message(STATUS "")

--- a/Hive/CMakeLists.txt
+++ b/Hive/CMakeLists.txt
@@ -1,7 +1,39 @@
 
+# ============================================================================
+# fmt library (logging and formatting)
+# ============================================================================
+
+# Configure fmt WITHOUT exceptions (game engine mode)
+set(FMT_EXCEPTIONS OFF CACHE BOOL "Disable exceptions in fmt" FORCE)
+set(FMT_INSTALL OFF CACHE BOOL "Don't install fmt" FORCE)
+
+# Add fmt as subdirectory
+add_subdirectory(extern/fmt EXCLUDE_FROM_ALL)
+
+# Silence warnings from fmt (external library)
+if(TARGET fmt)
+    target_compile_options(fmt PRIVATE
+        $<$<CXX_COMPILER_ID:Clang>:-w>
+        $<$<CXX_COMPILER_ID:GNU>:-w>
+        $<$<CXX_COMPILER_ID:MSVC>:/w>
+    )
+endif()
+
+# ============================================================================
+# Hive library
+# ============================================================================
+
 add_library(hive STATIC)
 target_include_directories(hive PUBLIC include PRIVATE src)
 target_precompile_headers(hive PRIVATE include/hive/precomp.h)
 
-target_sources(hive PRIVATE src/hive/core/log.cpp src/hive/core/module.cpp src/hive/core/moduleregistry.cpp)
+# Link fmt library
+target_link_libraries(hive PUBLIC fmt::fmt)
+
+target_sources(hive PRIVATE
+        src/hive/core/assert.cpp
+        src/hive/core/log.cpp
+        src/hive/core/module.cpp
+        src/hive/core/moduleregistry.cpp
+)
 

--- a/Hive/include/hive/core/assert.h
+++ b/Hive/include/hive/core/assert.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#if defined(_WIN32) || defined(_WIN64)
+    #define HIVE_PLATFORM_WINDOWS 1
+#elif defined(__linux__)
+    #define HIVE_PLATFORM_LINUX 1
+#elif defined(__APPLE__) && defined(__MACH__)
+    #define HIVE_PLATFORM_MACOS 1
+#else
+    #define HIVE_PLATFORM_UNKNOWN 1
+#endif
+
+#if defined(_MSC_VER)
+    #define HIVE_COMPILER_MSVC 1
+#elif defined(__clang__)
+    #define HIVE_COMPILER_CLANG 1
+#elif defined(__GNUC__)
+    #define HIVE_COMPILER_GCC 1
+#endif
+
+#if defined(NDEBUG) || defined(_NDEBUG)
+    #define HIVE_BUILD_RELEASE 1
+    #define HIVE_BUILD_DEBUG 0
+#else
+    #define HIVE_BUILD_RELEASE 0
+    #define HIVE_BUILD_DEBUG 1
+#endif
+
+#if HIVE_COMPILER_MSVC
+    #define HIVE_DEBUG_BREAK() __debugbreak()
+#elif HIVE_COMPILER_CLANG || HIVE_COMPILER_GCC
+    #if HIVE_PLATFORM_LINUX || HIVE_PLATFORM_MACOS
+        #include <signal.h>
+        #define HIVE_DEBUG_BREAK() raise(SIGTRAP)
+    #else
+        #define HIVE_DEBUG_BREAK() __builtin_trap()
+    #endif
+#else
+    #define HIVE_DEBUG_BREAK() ((void)0)
+#endif
+
+#if HIVE_COMPILER_MSVC
+    #define HIVE_FORCE_INLINE __forceinline
+#elif HIVE_COMPILER_CLANG || HIVE_COMPILER_GCC
+    #define HIVE_FORCE_INLINE __attribute__((always_inline)) inline
+#else
+    #define HIVE_FORCE_INLINE inline
+#endif
+
+#if HIVE_COMPILER_CLANG || HIVE_COMPILER_GCC
+    #define HIVE_LIKELY(x) __builtin_expect(!!(x), 1)
+    #define HIVE_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+    #define HIVE_LIKELY(x) (x)
+    #define HIVE_UNLIKELY(x) (x)
+#endif
+
+#include <source_location>
+#include <type_traits>
+#include <cstdint>
+
+namespace hive
+{
+    bool HandleAssertionFailure(
+        const char* file,
+        std::uint_least32_t line,
+        const char* function,
+        const char* message = nullptr);
+
+    // Assert: Debug only, zero cost in release, expr not evaluated in release
+    // NOTE: Currently only checks at runtime. In C++26, we could add compile-time
+    // validation using consteval diagnostics for better error messages when used
+    // in constexpr contexts.
+#if HIVE_BUILD_DEBUG
+    constexpr void Assert(
+        bool expr,
+        const char* message = nullptr,
+        const std::source_location& loc = std::source_location::current())
+    {
+        if (!std::is_constant_evaluated())
+        {
+            if (HIVE_UNLIKELY(!expr))
+            {
+                HandleAssertionFailure(loc.file_name(), loc.line(), loc.function_name(), message);
+            }
+        }
+    }
+#else
+    constexpr void Assert(bool, const char* = nullptr, const std::source_location& = std::source_location::current()) {}
+#endif
+
+    // Verify: Always evaluates expr (even in release), reports failure in debug only
+#if HIVE_BUILD_DEBUG
+    constexpr bool Verify(
+        bool expr,
+        const char* message = nullptr,
+        const std::source_location& loc = std::source_location::current())
+    {
+        if (!std::is_constant_evaluated())
+        {
+            if (HIVE_UNLIKELY(!expr))
+            {
+                HandleAssertionFailure(loc.file_name(), loc.line(), loc.function_name(), message);
+            }
+        }
+        return expr;
+    }
+#else
+    constexpr bool Verify(bool expr, const char* = nullptr, const std::source_location& = std::source_location::current())
+    {
+        return expr;
+    }
+#endif
+
+    // Check: Always evaluates and reports, even in release (use sparingly)
+    constexpr void Check(
+        bool expr,
+        const char* message = nullptr,
+        const std::source_location& loc = std::source_location::current())
+    {
+        if (!std::is_constant_evaluated())
+        {
+            if (HIVE_UNLIKELY(!expr))
+            {
+                HandleAssertionFailure(loc.file_name(), loc.line(), loc.function_name(), message);
+            }
+        }
+    }
+
+    // Unreachable: Marks code paths that should never execute
+#if HIVE_BUILD_DEBUG
+    [[noreturn]] inline void Unreachable(
+        const std::source_location& loc = std::source_location::current())
+    {
+        HandleAssertionFailure(loc.file_name(), loc.line(), loc.function_name(), "Unreachable code executed");
+        HIVE_DEBUG_BREAK();
+        std::abort();
+    }
+#else
+    [[noreturn]] inline void Unreachable(const std::source_location& = std::source_location::current())
+    {
+    #if HIVE_COMPILER_MSVC
+        __assume(0);
+    #elif HIVE_COMPILER_CLANG || HIVE_COMPILER_GCC
+        __builtin_unreachable();
+    #else
+        std::abort();
+    #endif
+    }
+#endif
+
+    // NotImplemented: Marks functionality that hasn't been implemented yet
+    [[noreturn]] inline void NotImplemented(
+        const std::source_location& loc = std::source_location::current())
+    {
+        HandleAssertionFailure(loc.file_name(), loc.line(), loc.function_name(), "Not implemented");
+        HIVE_DEBUG_BREAK();
+        std::abort();
+    }
+}
+
+

--- a/Hive/include/hive/core/module.h
+++ b/Hive/include/hive/core/module.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <vector>
+#include <string>
+#include <unordered_set>
+
 namespace hive
 {
     class ModuleContext
@@ -34,7 +38,7 @@ namespace hive
         bool IsInitialized() const { return m_IsInitialized; }
 
     protected:
-        virtual void DoConfigure(ModuleContext &context)
+        virtual void DoConfigure([[maybe_unused]] ModuleContext &context)
         {
         }
 

--- a/Hive/include/hive/core/moduleregistry.h
+++ b/Hive/include/hive/core/moduleregistry.h
@@ -25,6 +25,19 @@ namespace hive
         std::vector<ModuleFactoryFn> m_ModuleFactories;
         std::vector<std::unique_ptr<Module>> m_Modules;
     };
+
+    template<typename ModuleClass>
+    class ModuleRegistrar
+    {
+    public:
+        ModuleRegistrar()
+        {
+            ModuleRegistry::GetInstance().RegisterModule([]() -> std::unique_ptr<Module>
+            {
+                return std::make_unique<ModuleClass>();
+            });
+        }
+    };
 }
 
 #define REGISTER_MODULE(ModuleClass)                                                                \

--- a/Hive/include/hive/precomp.h
+++ b/Hive/include/hive/precomp.h
@@ -10,3 +10,4 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <optional>

--- a/Hive/include/hive/utils/functor.h
+++ b/Hive/include/hive/utils/functor.h
@@ -2,13 +2,13 @@
 
 namespace hive
 {
-    template <class>
+   template <class>
    struct max_sizeof;
 
    template <class... Ts>
    struct max_sizeof<std::tuple<Ts...>>
    {
-      static constexpr auto value = std::max({sizeof(Ts)...});
+      static constexpr auto value = (std::max)({sizeof(Ts)...});
    };
 
    template <class T>
@@ -20,7 +20,7 @@ namespace hive
    template <class... Ts>
    struct max_alignof<std::tuple<Ts...>>
    {
-      static constexpr auto value = std::max({alignof(Ts)...});
+      static constexpr auto value = (std::max)({alignof(Ts)...});
    };
 
    template <class T>

--- a/Hive/src/hive/core/assert.cpp
+++ b/Hive/src/hive/core/assert.cpp
@@ -1,0 +1,69 @@
+#include <hive/core/assert.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#if HIVE_PLATFORM_WINDOWS
+    #define WIN32_LEAN_AND_MEAN
+    #include <Windows.h>
+#endif
+
+namespace hive
+{
+    // Thread-local to avoid allocations
+    thread_local char s_AssertMessageBuffer[2048];
+
+    bool HandleAssertionFailure(
+        const char* file,
+        std::uint_least32_t line,
+        const char* function,
+        const char* message)
+    {
+        const char* filename = file;
+        const char* lastSlash = std::strrchr(file, '/');
+        const char* lastBackslash = std::strrchr(file, '\\');
+
+        if (lastSlash && lastBackslash)
+        {
+            filename = (lastSlash > lastBackslash) ? lastSlash + 1 : lastBackslash + 1;
+        }
+        else if (lastSlash)
+        {
+            filename = lastSlash + 1;
+        }
+        else if (lastBackslash)
+        {
+            filename = lastBackslash + 1;
+        }
+
+        if (message && message[0] != '\0')
+        {
+            std::snprintf(s_AssertMessageBuffer, sizeof(s_AssertMessageBuffer),
+                "Assertion failed\n"
+                "  File: %s:%d\n"
+                "  Function: %s\n"
+                "  Message: %s",
+                filename, line, function, message);
+        }
+        else
+        {
+            std::snprintf(s_AssertMessageBuffer, sizeof(s_AssertMessageBuffer),
+                "Assertion failed\n"
+                "  File: %s:%d\n"
+                "  Function: %s",
+                filename, line, function);
+        }
+
+        #if HIVE_PLATFORM_WINDOWS
+            OutputDebugStringA(s_AssertMessageBuffer);
+            OutputDebugStringA("\n");
+        #endif
+
+        std::fprintf(stderr, "%s\n", s_AssertMessageBuffer);
+
+        HIVE_DEBUG_BREAK();
+
+        return false;
+    }
+}

--- a/Hive/src/hive/core/module.cpp
+++ b/Hive/src/hive/core/module.cpp
@@ -29,6 +29,6 @@ namespace hive
             }
         }
 
-        return depCount == m_Context.GetDependencies().size();
+        return depCount == static_cast<int>(m_Context.GetDependencies().size());
     }
 }


### PR DESCRIPTION
Added fmt as a submodule and linked it for logging with modern formatting. Introduced hive/core/assert.h and assert.cpp for platform-aware assertion handling and debug breaks. Refactored logging to use type-safe fmt formatting, improved module and registry APIs, and updated CMake for better compiler flag management and platform detection.