### PR TITLE
Add Brood test and benchmark executables

### DIFF
--- a/Brood/CMakeLists.txt
+++ b/Brood/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.30.5)
+
+# Base test sources (always present)
+set(LARVAE_TEST_SOURCES
+    main.cpp
+)
+
+# Create the test executable
+add_executable(larvae_runner ${LARVAE_TEST_SOURCES})
+
+# Link against Larvae testing framework and modules to test
+target_link_libraries(larvae_runner PRIVATE
+    larvae
+    hive
+)
+
+# Set output directory
+set_target_properties(larvae_runner PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+# Add test to CTest
+enable_testing()
+add_test(NAME AllTests COMMAND larvae_runner)
+
+# Create the benchmark executable
+add_executable(larvae_benchmark
+    main_benchmark.cpp
+)
+
+target_link_libraries(larvae_benchmark PRIVATE
+    larvae
+    hive
+)
+
+set_target_properties(larvae_benchmark PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)

--- a/Brood/main.cpp
+++ b/Brood/main.cpp
@@ -1,0 +1,12 @@
+#include <larvae/larvae.h>
+
+#include <hive/core/assert.h>
+#include <hive/core/log.h>
+
+int main(int argc, char** argv)
+{
+    hive::LogManager logManager;
+    hive::ConsoleLogger logger{hive::LogManager::GetInstance()};
+
+    return larvae::RunAllTests(argc, argv);
+}

--- a/Brood/main_benchmark.cpp
+++ b/Brood/main_benchmark.cpp
@@ -1,0 +1,12 @@
+#include <larvae/larvae.h>
+#include <hive/core/log.h>
+#include <iostream>
+
+int main(int argc, char** argv)
+{
+    hive::LogManager logManager;
+    hive::ConsoleLogger logger{hive::LogManager::GetInstance()};
+
+    std::cout << "Larvae Benchmark Runner\n\n";
+    return larvae::RunAllBenchmarks(argc, argv);
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,7 @@ endforeach()
 add_subdirectory(Hive)
 add_subdirectory(Terra)
 add_subdirectory(Larvae)
+add_subdirectory(Brood)
 #add_subdirectory(Testbed)
 #add_subdirectory(Cells)
 


### PR DESCRIPTION
Introduces the Brood directory with CMake configuration and main files for running Larvae tests and benchmarks. Updates the root CMakeLists.txt to include Brood as a subdirectory.