### PR TITLE
Add Comb module for platform memory management

### DIFF
--- a/Brood/CMakeLists.txt
+++ b/Brood/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.30.5)
 # Base test sources (always present)
 set(LARVAE_TEST_SOURCES
     main.cpp
+    ../Comb/tests/test_platform.cpp
 )
 
 # Create the test executable
@@ -12,6 +13,11 @@ add_executable(larvae_runner ${LARVAE_TEST_SOURCES})
 target_link_libraries(larvae_runner PRIVATE
     larvae
     hive
+    comb
+)
+
+target_include_directories(larvae_runner PRIVATE
+    ${CMAKE_SOURCE_DIR}/Comb/include
 )
 
 # Set output directory
@@ -31,6 +37,11 @@ add_executable(larvae_benchmark
 target_link_libraries(larvae_benchmark PRIVATE
     larvae
     hive
+    comb
+)
+
+target_include_directories(larvae_benchmark PRIVATE
+    ${CMAKE_SOURCE_DIR}/Comb/include
 )
 
 set_target_properties(larvae_benchmark PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,7 @@ add_subdirectory(Hive)
 add_subdirectory(Terra)
 add_subdirectory(Larvae)
 add_subdirectory(Brood)
+add_subdirectory(Comb)
 #add_subdirectory(Testbed)
 #add_subdirectory(Cells)
 

--- a/Comb/CMakeLists.txt
+++ b/Comb/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.30.5)
+
+add_library(comb STATIC)
+target_include_directories(comb PUBLIC include PRIVATE src)
+target_precompile_headers(comb PRIVATE include/comb/precomp.h)
+
+# Link against Hive (core module)
+target_link_libraries(comb PUBLIC hive)
+
+# ============================================================================
+# Memory Debugging Option
+# ============================================================================
+
+set(COMB_ENABLE_MEM_DEBUG ON CACHE BOOL "Enable comprehensive memory debugging (SLOW! 10-100x overhead)" FORCE)
+
+if(COMB_ENABLE_MEM_DEBUG)
+    target_compile_definitions(comb PUBLIC COMB_MEM_DEBUG=1)
+    message(STATUS "Comb: Memory debugging ENABLED (slow! Use only for debugging sessions)")
+
+    # Platform-specific callstack capture (optional, very expensive)
+    option(COMB_ENABLE_CALLSTACKS "Enable callstack capture (VERY SLOW! 100x overhead)" OFF)
+    if(COMB_ENABLE_CALLSTACKS)
+        target_compile_definitions(comb PUBLIC COMB_MEM_DEBUG_CALLSTACKS=1)
+        message(STATUS "Comb: Callstack capture ENABLED (extremely slow!)")
+
+        # Windows: Link dbghelp.lib for symbol resolution
+        if(WIN32)
+            target_link_libraries(comb PRIVATE dbghelp)
+        endif()
+    else()
+        target_compile_definitions(comb PUBLIC COMB_MEM_DEBUG_CALLSTACKS=0)
+    endif()
+else()
+    target_compile_definitions(comb PUBLIC COMB_MEM_DEBUG=0)
+    target_compile_definitions(comb PUBLIC COMB_MEM_DEBUG_CALLSTACKS=0)
+    message(STATUS "Comb: Memory debugging disabled (zero overhead)")
+endif()
+
+# Base allocator sources (always present)
+target_sources(comb PRIVATE
+    src/comb/combmodule.cpp
+    src/comb/platform.cpp
+)

--- a/Comb/include/comb/combmodule.h
+++ b/Comb/include/comb/combmodule.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <hive/core/module.h>
+#include <hive/core/log.h>
+
+namespace comb
+{
+    extern const hive::LogCategory LogCombRoot;
+
+    class CombModule : public hive::Module
+    {
+    public:
+        CombModule() = default;
+        ~CombModule() override = default;
+
+        const char* GetName() const override { return GetStaticName(); }
+        static const char* GetStaticName() { return "Comb"; }
+
+    protected:
+        void DoConfigure(hive::ModuleContext& context) override;
+        void DoInitialize() override;
+        void DoShutdown() override;
+    };
+}

--- a/Comb/include/comb/platform.h
+++ b/Comb/include/comb/platform.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstddef>
+
+namespace comb
+{
+    /**
+     * Get the system page size
+     * @return Page size in bytes (typically 4096)
+     */
+    size_t GetPageSize();
+
+    /**
+     * Allocate virtual memory pages from the OS
+     * @param size Number of bytes to allocate (should be multiple of page size)
+     * @return Pointer to allocated memory, or nullptr on failure
+     */
+    void* AllocatePages(size_t size);
+
+    /**
+     * Free virtual memory pages back to the OS
+     * @param ptr Pointer to memory allocated by AllocatePages
+     * @param size Size that was originally allocated
+     */
+    void FreePages(void* ptr, size_t size);
+}

--- a/Comb/include/comb/precomp.h
+++ b/Comb/include/comb/precomp.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <hive/precomp.h>
+
+// Add module-specific precompiled headers here

--- a/Comb/include/comb/utils.h
+++ b/Comb/include/comb/utils.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <hive/core/assert.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <array>
+#include <algorithm>
+#include <concepts>
+
+namespace comb
+{
+    /**
+     * Check if a value is a power of 2
+     * @param value Value to check
+     * @return True if value is a power of 2, false otherwise
+     */
+    constexpr bool IsPowerOfTwo(size_t value)
+    {
+        return value > 0 && (value & (value - 1)) == 0;
+    }
+
+    /**
+     * Check if an address is aligned to the specified alignment
+     * @param address Address to check
+     * @param alignment Alignment requirement (must be power of 2)
+     * @return True if address is aligned, false otherwise
+     */
+    constexpr bool IsAligned(uintptr_t address, size_t alignment)
+    {
+        hive::Assert(IsPowerOfTwo(alignment), "Alignment must be power of 2");
+        return (address & (alignment - 1)) == 0;
+    }
+
+    /**
+     * Check if a pointer is aligned to the specified alignment
+     * @param ptr Pointer to check
+     * @param alignment Alignment requirement (must be power of 2)
+     * @return True if pointer is aligned, false otherwise
+     */
+    inline bool IsAligned(const void* ptr, size_t alignment)
+    {
+        return IsAligned(reinterpret_cast<uintptr_t>(ptr), alignment);
+    }
+
+    /**
+     * Round up a value to the next multiple of alignment
+     * @param value Value to align
+     * @param alignment Alignment requirement (must be power of 2)
+     * @return Aligned value
+     */
+    constexpr size_t AlignUp(size_t value, size_t alignment)
+    {
+        hive::Assert(IsPowerOfTwo(alignment), "Alignment must be power of 2");
+        return (value + (alignment - 1)) & ~(alignment - 1);
+    }
+
+    /**
+     * Round up a pointer to the next multiple of alignment
+     * @param ptr Pointer to align
+     * @param alignment Alignment requirement (must be power of 2)
+     * @return Aligned pointer
+     */
+    inline void* AlignUp(void* ptr, size_t alignment)
+    {
+        const auto addr = reinterpret_cast<uintptr_t>(ptr);
+        const auto aligned = AlignUp(addr, alignment);
+        return reinterpret_cast<void*>(aligned);
+    }
+
+    /**
+     * Find the next power of 2 greater than or equal to value
+     * @param value Input value
+     * @return Next power of 2
+     */
+    constexpr size_t NextPowerOfTwo(size_t value)
+    {
+        if (value == 0) return 1;
+
+        if (IsPowerOfTwo(value)) return value;
+
+        value--;
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+
+        if constexpr (sizeof(size_t) == 8)
+        {
+            value |= value >> 32;
+        }
+
+        return value + 1;
+    }
+
+    /**
+     * Calculate padding needed to align an address
+     * @param address Current address
+     * @param alignment Alignment requirement (must be power of 2)
+     * @return Number of bytes of padding needed
+     */
+    constexpr size_t GetAlignmentPadding(uintptr_t address, size_t alignment)
+    {
+        hive::Assert(IsPowerOfTwo(alignment), "Alignment must be power of 2");
+        const auto padding = AlignUp(address, alignment) - address;
+        return padding;
+    }
+
+    /**
+     * Calculate padding needed to align a pointer
+     * @param ptr Current pointer
+     * @param alignment Alignment requirement (must be power of 2)
+     * @return Number of bytes of padding needed
+     */
+    inline size_t GetAlignmentPadding(const void* ptr, size_t alignment)
+    {
+        return GetAlignmentPadding(reinterpret_cast<uintptr_t>(ptr), alignment);
+    }
+
+    /**
+     * Create a constexpr array from variadic arguments
+     * All arguments must be of the same type
+     * @tparam T Element type
+     * @tparam Ts... Additional element types (must be same as T)
+     * @param n First element
+     * @param ns... Remaining elements
+     * @return constexpr array containing all elements
+     */
+    template<typename T, std::same_as<T>... Ts>
+    constexpr std::array<T, sizeof...(Ts) + 1> MakeArray(T n, Ts... ns)
+    {
+        return {n, ns...};
+    }
+
+    /**
+     * Check if a container is sorted in ascending order
+     * @tparam T Container type
+     * @param container Container to check
+     * @return True if sorted, false otherwise
+     */
+    template<typename T>
+    constexpr bool IsSorted(const T& container)
+    {
+        return std::is_sorted(std::begin(container), std::end(container));
+    }
+}

--- a/Comb/src/comb/combmodule.cpp
+++ b/Comb/src/comb/combmodule.cpp
@@ -1,0 +1,30 @@
+#include <comb/precomp.h>
+#include <comb/combmodule.h>
+#include <hive/core/log.h>
+
+namespace comb
+{
+    const hive::LogCategory LogCombRoot{"Comb", &hive::LogHiveRoot};
+
+    void CombModule::DoConfigure([[maybe_unused]] hive::ModuleContext& context)
+    {
+        // Add dependencies here
+        // Example: context.AddDependency<OtherModule>();
+
+        hive::LogInfo(hive::LogHiveRoot, "Comb module configured");
+    }
+
+    void CombModule::DoInitialize()
+    {
+        hive::LogInfo(hive::LogHiveRoot, "Comb module initialized");
+
+        // Initialize your module here
+    }
+
+    void CombModule::DoShutdown()
+    {
+        hive::LogInfo(hive::LogHiveRoot, "Comb module shutdown");
+
+        // Cleanup your module here
+    }
+}

--- a/Comb/src/comb/platform.cpp
+++ b/Comb/src/comb/platform.cpp
@@ -1,0 +1,80 @@
+#include <comb/precomp.h>
+#include <comb/platform.h>
+
+// Platform-specific headers
+#if defined(_WIN32)
+    #include <windows.h>
+#elif defined(__unix__) || defined(__APPLE__)
+    #include <sys/mman.h>
+    #include <unistd.h>
+#else
+    #error "Unsupported platform"
+#endif
+
+namespace comb
+{
+    size_t GetPageSize()
+    {
+#if defined(_WIN32)
+        SYSTEM_INFO info{};
+        GetSystemInfo(&info);
+        return info.dwPageSize;
+#elif defined(__unix__) || defined(__APPLE__)
+        return static_cast<size_t>(sysconf(_SC_PAGESIZE));
+#else
+        #error "Unsupported platform"
+#endif
+    }
+
+    void* AllocatePages(size_t size)
+    {
+#if defined(_WIN32)
+        void* ptr = VirtualAlloc(
+            nullptr,                  // Let system choose address
+            size,                     // Size in bytes
+            MEM_RESERVE | MEM_COMMIT, // Reserve and commit pages
+            PAGE_READWRITE            // Read/write access
+        );
+        return ptr;
+#elif defined(__unix__) || defined(__APPLE__)
+        void* ptr = mmap(
+            nullptr,               // Let kernel choose address
+            size,                  // Size in bytes
+            PROT_READ | PROT_WRITE,// Read/write permissions
+            MAP_PRIVATE | MAP_ANONYMOUS, // Private, not backed by file
+            -1,                    // No file descriptor (anonymous)
+            0                      // No offset (anonymous)
+        );
+
+        if (ptr == MAP_FAILED)
+        {
+            return nullptr;
+        }
+
+        return ptr;
+#else
+        #error "Unsupported platform"
+#endif
+    }
+
+    void FreePages(void* ptr, size_t size)
+    {
+        if (!ptr) return;
+
+#if defined(_WIN32)
+        (void)size; // Windows doesn't need size for VirtualFree with MEM_RELEASE
+        VirtualFree(
+            ptr,         // Address to free
+            0,           // Must be 0 with MEM_RELEASE
+            MEM_RELEASE  // Release reserved pages
+        );
+#elif defined(__unix__) || defined(__APPLE__)
+        munmap(
+            ptr,  // Address to unmap
+            size  // Size in bytes
+        );
+#else
+        #error "Unsupported platform"
+#endif
+    }
+}

--- a/Comb/tests/test_platform.cpp
+++ b/Comb/tests/test_platform.cpp
@@ -1,0 +1,255 @@
+#include <larvae/larvae.h>
+#include <comb/platform.h>
+#include <cstring>
+
+namespace {
+    auto test1 = larvae::RegisterTest("MemoryPlatform", "GetPageSizeReturnsValidValue", []() {
+        const auto page_size = comb::GetPageSize();
+
+        // Page size should be non-zero
+        larvae::AssertGreaterThan(page_size, 0u);
+
+        // Page size should be a power of 2
+        larvae::AssertTrue((page_size & (page_size - 1)) == 0);
+
+        // Typical page sizes are 4096, 8192, or 16384
+        larvae::AssertGreaterEqual(page_size, 4096u);
+        larvae::AssertLessEqual(page_size, 65536u);
+    });
+
+    auto test2 = larvae::RegisterTest("MemoryPlatform", "AllocatePagesReturnsValidPointer", []() {
+        const auto page_size = comb::GetPageSize();
+        void* ptr = comb::AllocatePages(page_size);
+
+        larvae::AssertNotNull(ptr);
+
+        comb::FreePages(ptr, page_size);
+    });
+
+    auto test3 = larvae::RegisterTest("MemoryPlatform", "AllocatePagesReturnsNullOnZeroSize", []() {
+        void* ptr = comb::AllocatePages(0);
+
+        // Some platforms might return nullptr for size 0
+        // This is platform-dependent behavior
+        if (ptr)
+        {
+            comb::FreePages(ptr, 0);
+        }
+
+        // Test passes regardless - we're just checking it doesn't crash
+        larvae::AssertTrue(true);
+    });
+
+    auto test4 = larvae::RegisterTest("MemoryPlatform", "AllocatedMemoryIsReadable", []() {
+        const auto page_size = comb::GetPageSize();
+        void* ptr = comb::AllocatePages(page_size);
+
+        larvae::AssertNotNull(ptr);
+
+        // Try to read from the allocated memory
+        auto* byte_ptr = static_cast<unsigned char*>(ptr);
+        volatile unsigned char value = byte_ptr[0];
+        (void)value; // Use the value to prevent optimization
+
+        // If we got here, reading succeeded
+        larvae::AssertTrue(true);
+
+        comb::FreePages(ptr, page_size);
+    });
+
+    auto test5 = larvae::RegisterTest("MemoryPlatform", "AllocatedMemoryIsWritable", []() {
+        const auto page_size = comb::GetPageSize();
+        void* ptr = comb::AllocatePages(page_size);
+
+        larvae::AssertNotNull(ptr);
+
+        // Try to write to the allocated memory
+        auto* byte_ptr = static_cast<unsigned char*>(ptr);
+        byte_ptr[0] = 42;
+        byte_ptr[page_size - 1] = 99;
+
+        // Verify writes
+        larvae::AssertEqual(byte_ptr[0], static_cast<unsigned char>(42));
+        larvae::AssertEqual(byte_ptr[page_size - 1], static_cast<unsigned char>(99));
+
+        comb::FreePages(ptr, page_size);
+    });
+
+    auto test6 = larvae::RegisterTest("MemoryPlatform", "AllocateMultiplePages", []() {
+        const auto page_size = comb::GetPageSize();
+        const auto alloc_size = page_size * 4;
+        void* ptr = comb::AllocatePages(alloc_size);
+
+        larvae::AssertNotNull(ptr);
+
+        // Write to different pages
+        auto* byte_ptr = static_cast<unsigned char*>(ptr);
+        byte_ptr[0] = 1;                           // First page
+        byte_ptr[page_size] = 2;                   // Second page
+        byte_ptr[page_size * 2] = 3;               // Third page
+        byte_ptr[page_size * 3] = 4;               // Fourth page
+        byte_ptr[alloc_size - 1] = 5;              // Last byte
+
+        // Verify all writes
+        larvae::AssertEqual(byte_ptr[0], static_cast<unsigned char>(1));
+        larvae::AssertEqual(byte_ptr[page_size], static_cast<unsigned char>(2));
+        larvae::AssertEqual(byte_ptr[page_size * 2], static_cast<unsigned char>(3));
+        larvae::AssertEqual(byte_ptr[page_size * 3], static_cast<unsigned char>(4));
+        larvae::AssertEqual(byte_ptr[alloc_size - 1], static_cast<unsigned char>(5));
+
+        comb::FreePages(ptr, alloc_size);
+    });
+
+    auto test7 = larvae::RegisterTest("MemoryPlatform", "FreePagesWithNullptrIsSafe", []() {
+        const auto page_size = comb::GetPageSize();
+
+        // Should not crash
+        comb::FreePages(nullptr, page_size);
+        comb::FreePages(nullptr, 0);
+
+        larvae::AssertTrue(true);
+    });
+
+    auto test8 = larvae::RegisterTest("MemoryPlatform", "MultipleAllocationsAreIndependent", []() {
+        const auto page_size = comb::GetPageSize();
+
+        void* ptr1 = comb::AllocatePages(page_size);
+        void* ptr2 = comb::AllocatePages(page_size);
+        void* ptr3 = comb::AllocatePages(page_size);
+
+        larvae::AssertNotNull(ptr1);
+        larvae::AssertNotNull(ptr2);
+        larvae::AssertNotNull(ptr3);
+
+        // Pointers should be different
+        larvae::AssertNotEqual(ptr1, ptr2);
+        larvae::AssertNotEqual(ptr2, ptr3);
+        larvae::AssertNotEqual(ptr1, ptr3);
+
+        // Write to each allocation
+        static_cast<unsigned char*>(ptr1)[0] = 11;
+        static_cast<unsigned char*>(ptr2)[0] = 22;
+        static_cast<unsigned char*>(ptr3)[0] = 33;
+
+        // Verify isolation
+        larvae::AssertEqual(static_cast<unsigned char*>(ptr1)[0], static_cast<unsigned char>(11));
+        larvae::AssertEqual(static_cast<unsigned char*>(ptr2)[0], static_cast<unsigned char>(22));
+        larvae::AssertEqual(static_cast<unsigned char*>(ptr3)[0], static_cast<unsigned char>(33));
+
+        // Free in different order
+        comb::FreePages(ptr2, page_size);
+        comb::FreePages(ptr1, page_size);
+        comb::FreePages(ptr3, page_size);
+    });
+
+    auto test9 = larvae::RegisterTest("MemoryPlatform", "LargeAllocation", []() {
+        const auto page_size = comb::GetPageSize();
+        const auto alloc_size = page_size * 256; // 1 MB if page size is 4 KB
+
+        void* ptr = comb::AllocatePages(alloc_size);
+
+        larvae::AssertNotNull(ptr);
+
+        // Write pattern across large allocation
+        auto* byte_ptr = static_cast<unsigned char*>(ptr);
+        for (size_t i = 0; i < alloc_size; i += page_size)
+        {
+            byte_ptr[i] = static_cast<unsigned char>(i / page_size);
+        }
+
+        // Verify pattern
+        for (size_t i = 0; i < alloc_size; i += page_size)
+        {
+            larvae::AssertEqual(byte_ptr[i], static_cast<unsigned char>(i / page_size));
+        }
+
+        comb::FreePages(ptr, alloc_size);
+    });
+
+    auto test10 = larvae::RegisterTest("MemoryPlatform", "AllocateNonPageAlignedSize", []() {
+        const auto page_size = comb::GetPageSize();
+        const auto odd_size = page_size + 100; // Not aligned to page size
+
+        void* ptr = comb::AllocatePages(odd_size);
+
+        larvae::AssertNotNull(ptr);
+
+        // OS should round up, so we can safely access the odd_size bytes
+        auto* byte_ptr = static_cast<unsigned char*>(ptr);
+        byte_ptr[0] = 1;
+        byte_ptr[odd_size - 1] = 2;
+
+        larvae::AssertEqual(byte_ptr[0], static_cast<unsigned char>(1));
+        larvae::AssertEqual(byte_ptr[odd_size - 1], static_cast<unsigned char>(2));
+
+        comb::FreePages(ptr, odd_size);
+    });
+
+    auto test11 = larvae::RegisterTest("MemoryPlatform", "MemsetOnAllocatedPages", []() {
+        const auto page_size = comb::GetPageSize();
+        const auto alloc_size = page_size * 2;
+
+        void* ptr = comb::AllocatePages(alloc_size);
+        larvae::AssertNotNull(ptr);
+
+        // Fill with pattern
+        std::memset(ptr, 0xAB, alloc_size);
+
+        // Verify pattern
+        auto* byte_ptr = static_cast<unsigned char*>(ptr);
+        for (size_t i = 0; i < alloc_size; ++i)
+        {
+            if (byte_ptr[i] != 0xAB)
+            {
+                larvae::AssertTrue(false); // Pattern mismatch
+            }
+        }
+
+        larvae::AssertTrue(true);
+
+        comb::FreePages(ptr, alloc_size);
+    });
+
+    class PlatformFixture : public larvae::TestFixture
+    {
+    public:
+        void SetUp() override
+        {
+            page_size = comb::GetPageSize();
+            ptr1 = comb::AllocatePages(page_size);
+            ptr2 = comb::AllocatePages(page_size * 2);
+        }
+
+        void TearDown() override
+        {
+            if (ptr1) comb::FreePages(ptr1, page_size);
+            if (ptr2) comb::FreePages(ptr2, page_size * 2);
+        }
+
+        size_t page_size{0};
+        void* ptr1{nullptr};
+        void* ptr2{nullptr};
+    };
+
+    auto test12 = larvae::RegisterTestWithFixture<PlatformFixture>(
+        "PlatformFixture", "AllocationsInFixture",
+        [](PlatformFixture& f) {
+            larvae::AssertNotNull(f.ptr1);
+            larvae::AssertNotNull(f.ptr2);
+            larvae::AssertNotEqual(f.ptr1, f.ptr2);
+
+            // Write to both
+            static_cast<unsigned char*>(f.ptr1)[0] = 100;
+            static_cast<unsigned char*>(f.ptr2)[0] = 200;
+
+            larvae::AssertEqual(static_cast<unsigned char*>(f.ptr1)[0], static_cast<unsigned char>(100));
+            larvae::AssertEqual(static_cast<unsigned char*>(f.ptr2)[0], static_cast<unsigned char>(200));
+        });
+
+    auto test13 = larvae::RegisterTestWithFixture<PlatformFixture>(
+        "PlatformFixture", "PageSizeIsConsistent",
+        [](PlatformFixture& f) {
+            const auto page_size2 = comb::GetPageSize();
+            larvae::AssertEqual(f.page_size, page_size2);
+        });
+}


### PR DESCRIPTION
Introduces the new Comb module with platform abstraction for memory page allocation and utilities. Adds CMake integration, headers, implementation, and a comprehensive test suite for memory operations. Brood's test and benchmark targets now depend on Comb and include its tests.