### PR TITLE
Add MemDebug build type and Clang sanitizer support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Build types
-set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo" CACHE STRING "" FORCE)
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;MemDebug" CACHE STRING "" FORCE)
 
 # ============================================================================
 # Engine Options
@@ -48,6 +48,17 @@ option(HIVE_ENABLE_LTO "Enable Link-Time Optimization (slower compile, better ru
 option(HIVE_ENABLE_FAST_MATH "Enable fast math optimizations (less precise)" OFF)
 option(HIVE_WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 option(HIVE_ENABLE_SIMD "Enable SIMD optimizations (SSE2)" ON)
+
+# Sanitizer options (for MemDebug builds with Clang)
+option(HIVE_ENABLE_SANITIZERS "Enable sanitizers (requires Clang)" OFF)
+set(HIVE_SANITIZER_TYPE "Address" CACHE STRING "Sanitizer type: Address, UndefinedBehavior, Thread, Memory")
+set_property(CACHE HIVE_SANITIZER_TYPE PROPERTY STRINGS "Address" "UndefinedBehavior" "Thread" "Memory")
+
+# Clang sanitizer runtimes on Windows are built with static CRT (/MT)
+# We must match this to avoid RuntimeLibrary mismatch linker errors
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "MemDebug" AND HIVE_ENABLE_SANITIZERS)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded" CACHE STRING "" FORCE)
+endif()
 
 # ============================================================================
 # Compiler Flags - ALL PLATFORMS
@@ -180,6 +191,46 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         add_compile_options(-O2 -g)
     endif()
 
+    # MemDebug flags (Debug with sanitizers)
+    if(CMAKE_BUILD_TYPE STREQUAL "MemDebug")
+        add_compile_options(-O1 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls)
+        add_compile_definitions(_GLIBCXX_DEBUG)
+
+        if(HIVE_ENABLE_SANITIZERS)
+            if(HIVE_SANITIZER_TYPE STREQUAL "Address")
+                # AddressSanitizer: memory errors (buffer overflow, use-after-free, etc.)
+                add_compile_options(-fsanitize=address)
+                add_link_options(-fsanitize=address)
+                message(STATUS "AddressSanitizer enabled")
+            elseif(HIVE_SANITIZER_TYPE STREQUAL "UndefinedBehavior")
+                # UBSan: undefined behavior (signed overflow, null deref, etc.)
+                # On Windows, exclude alignment and function checks (cause DEP violations with Clang)
+                if(WIN32)
+                    add_compile_options(-fsanitize=undefined -fno-sanitize=alignment,function,vptr)
+                    add_link_options(-fsanitize=undefined -fno-sanitize=alignment,function,vptr)
+                else()
+                    add_compile_options(-fsanitize=undefined)
+                    add_link_options(-fsanitize=undefined)
+                endif()
+                message(STATUS "UndefinedBehaviorSanitizer enabled")
+            elseif(HIVE_SANITIZER_TYPE STREQUAL "Thread")
+                # ThreadSanitizer: data races
+                add_compile_options(-fsanitize=thread)
+                add_link_options(-fsanitize=thread)
+                message(STATUS "ThreadSanitizer enabled")
+            elseif(HIVE_SANITIZER_TYPE STREQUAL "Memory")
+                # MemorySanitizer: uninitialized reads (Clang only, not on Windows)
+                if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT WIN32)
+                    add_compile_options(-fsanitize=memory -fsanitize-memory-track-origins)
+                    add_link_options(-fsanitize=memory)
+                    message(STATUS "MemorySanitizer enabled")
+                else()
+                    message(WARNING "MemorySanitizer only available with Clang on Linux/macOS")
+                endif()
+            endif()
+        endif()
+    endif()
+
     if(HIVE_ENABLE_SIMD)
         add_compile_options(-msse2)
     endif()
@@ -236,6 +287,13 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
             HIVE_ENABLE_ASSERTS=0
             HIVE_LOG_LEVEL=2
     )
+elseif(CMAKE_BUILD_TYPE STREQUAL "MemDebug")
+    add_compile_definitions(
+            HIVE_DEBUG=1
+            HIVE_MEMDEBUG=1
+            HIVE_ENABLE_ASSERTS=1
+            HIVE_LOG_LEVEL=0
+    )
 endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -266,12 +324,15 @@ message(STATUS "C++ Standard:       ${CMAKE_CXX_STANDARD}")
 message(STATUS "Compiler:           ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
 message(STATUS "")
 message(STATUS "Optimizations:")
-message(STATUS "  RTTI:             ❌ Disabled")
-message(STATUS "  Exceptions:       ❌ Disabled")
+message(STATUS "  RTTI:             OFF")
+message(STATUS "  Exceptions:       OFF")
 message(STATUS "  LTO:              ${HIVE_ENABLE_LTO}")
 message(STATUS "  Fast Math:        ${HIVE_ENABLE_FAST_MATH}")
 message(STATUS "  SIMD:             ${HIVE_ENABLE_SIMD}")
 message(STATUS "  Warnings->Errors: ${HIVE_WARNINGS_AS_ERRORS}")
+if(HIVE_ENABLE_SANITIZERS)
+    message(STATUS "  Sanitizers:       ${HIVE_SANITIZER_TYPE}")
+endif()
 message(STATUS "")
 message(STATUS "Engine Options:")
 message(STATUS "  Vulkan:           ${swarm_use_vulkan}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,9 +2,84 @@
   "version": 8,
   "configurePresets": [
     {
+      "name": "llvm-windows-base",
+      "hidden": true,
+      "displayName": "LLVM Windows Base",
+      "description": "Base configuration for LLVM/Clang on Windows",
+      "generator": "Ninja",
+      "toolchainFile": "${sourceDir}/cmake/toolchains/llvm-windows.cmake",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "SWARM_USE_VULKAN": "ON",
+        "terra_use_glfw": "ON"
+      }
+    },
+    {
+      "name": "llvm-windows-debug",
+      "inherits": "llvm-windows-base",
+      "displayName": "LLVM Windows Debug",
+      "description": "Debug build with full symbols and no optimization",
+      "binaryDir": "${sourceDir}/out/build/llvm-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "HIVE_ENABLE_LTO": "OFF",
+        "HIVE_WARNINGS_AS_ERRORS": "OFF"
+      }
+    },
+    {
+      "name": "llvm-windows-release",
+      "inherits": "llvm-windows-base",
+      "displayName": "LLVM Windows Release",
+      "description": "Optimized release build with LTO",
+      "binaryDir": "${sourceDir}/out/build/llvm-release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "HIVE_ENABLE_LTO": "ON",
+        "HIVE_ENABLE_SIMD": "ON"
+      }
+    },
+    {
+      "name": "llvm-windows-relwithdebinfo",
+      "inherits": "llvm-windows-base",
+      "displayName": "LLVM Windows RelWithDebInfo",
+      "description": "Optimized build with debug symbols",
+      "binaryDir": "${sourceDir}/out/build/llvm-relwithdebinfo",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "HIVE_ENABLE_LTO": "ON"
+      }
+    },
+    {
+      "name": "llvm-windows-memdebug",
+      "inherits": "llvm-windows-base",
+      "displayName": "LLVM Windows MemDebug",
+      "description": "Debug build with AddressSanitizer for memory debugging",
+      "binaryDir": "${sourceDir}/out/build/llvm-memdebug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MemDebug",
+        "HIVE_ENABLE_LTO": "OFF",
+        "HIVE_ENABLE_SANITIZERS": "ON",
+        "HIVE_SANITIZER_TYPE": "Address"
+      }
+    },
+    {
+      "name": "llvm-windows-ubsan",
+      "inherits": "llvm-windows-base",
+      "displayName": "LLVM Windows UBSan",
+      "description": "Debug build with UndefinedBehaviorSanitizer",
+      "binaryDir": "${sourceDir}/out/build/llvm-ubsan",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MemDebug",
+        "HIVE_ENABLE_LTO": "OFF",
+        "HIVE_ENABLE_SANITIZERS": "ON",
+        "HIVE_SANITIZER_TYPE": "UndefinedBehavior"
+      }
+    },
+    {
       "name": "LINUX_GLFW_VULKAN",
-      "displayName": "Clang 20.1.8 x86_64-pc-linux-gnu",
+      "displayName": "Linux Clang Debug",
       "description": "Using compilers: C = /usr/bin/clang, CXX = /usr/bin/clang++",
+      "generator": "Ninja",
       "binaryDir": "${sourceDir}/out/build/${presetName}",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "/usr/bin/clang",
@@ -12,8 +87,29 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "SWARM_USE_VULKAN": "ON",
         "terra_use_glfw": "ON"
-
       }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "llvm-windows-debug",
+      "configurePreset": "llvm-windows-debug"
+    },
+    {
+      "name": "llvm-windows-release",
+      "configurePreset": "llvm-windows-release"
+    },
+    {
+      "name": "llvm-windows-relwithdebinfo",
+      "configurePreset": "llvm-windows-relwithdebinfo"
+    },
+    {
+      "name": "llvm-windows-memdebug",
+      "configurePreset": "llvm-windows-memdebug"
+    },
+    {
+      "name": "llvm-windows-ubsan",
+      "configurePreset": "llvm-windows-ubsan"
     }
   ]
 }

--- a/Comb/CMakeLists.txt
+++ b/Comb/CMakeLists.txt
@@ -11,7 +11,14 @@ target_link_libraries(comb PUBLIC hive)
 # Memory Debugging Option
 # ============================================================================
 
-set(COMB_ENABLE_MEM_DEBUG ON CACHE BOOL "Enable comprehensive memory debugging (SLOW! 10-100x overhead)" FORCE)
+# Auto-enable memory debugging for Debug/MemDebug builds, disable for Release
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "MemDebug")
+    set(COMB_ENABLE_MEM_DEBUG_DEFAULT ON)
+else()
+    set(COMB_ENABLE_MEM_DEBUG_DEFAULT OFF)
+endif()
+
+option(COMB_ENABLE_MEM_DEBUG "Enable comprehensive memory debugging (SLOW! 10-100x overhead)" ${COMB_ENABLE_MEM_DEBUG_DEFAULT})
 
 if(COMB_ENABLE_MEM_DEBUG)
     target_compile_definitions(comb PUBLIC COMB_MEM_DEBUG=1)

--- a/cmake/toolchains/llvm-windows.cmake
+++ b/cmake/toolchains/llvm-windows.cmake
@@ -1,0 +1,34 @@
+# LLVM/Clang Toolchain for Windows
+# Usage: cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/llvm-windows.cmake ..
+
+set(CMAKE_SYSTEM_NAME Windows)
+
+# Find LLVM installation
+# Priority: Environment variable > Common install locations
+if(DEFINED ENV{LLVM_PATH})
+    set(LLVM_ROOT "$ENV{LLVM_PATH}")
+elseif(EXISTS "C:/Program Files/LLVM")
+    set(LLVM_ROOT "C:/Program Files/LLVM")
+elseif(EXISTS "C:/LLVM")
+    set(LLVM_ROOT "C:/LLVM")
+else()
+    message(FATAL_ERROR "LLVM not found. Set LLVM_PATH environment variable or install LLVM to C:/Program Files/LLVM")
+endif()
+
+# Set compilers
+set(CMAKE_C_COMPILER "${LLVM_ROOT}/bin/clang.exe" CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER "${LLVM_ROOT}/bin/clang++.exe" CACHE FILEPATH "C++ compiler")
+set(CMAKE_AR "${LLVM_ROOT}/bin/llvm-ar.exe" CACHE FILEPATH "Archiver")
+set(CMAKE_RANLIB "${LLVM_ROOT}/bin/llvm-ranlib.exe" CACHE FILEPATH "Ranlib")
+set(CMAKE_LINKER "${LLVM_ROOT}/bin/lld-link.exe" CACHE FILEPATH "Linker")
+
+# Use LLD linker
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+
+# Target triple for Windows x64
+set(CMAKE_C_COMPILER_TARGET "x86_64-pc-windows-msvc")
+set(CMAKE_CXX_COMPILER_TARGET "x86_64-pc-windows-msvc")
+
+message(STATUS "LLVM Toolchain: ${LLVM_ROOT}")


### PR DESCRIPTION
Introduces a 'MemDebug' build type for enhanced memory debugging and integrates Clang sanitizer options (Address, UndefinedBehavior, Thread, Memory) into the CMake configuration. Adds LLVM/Clang toolchain file for Windows and updates CMake presets to support new build types and sanitizers. Memory debugging for the 'comb' target is now auto-enabled for Debug/MemDebug builds.