### PR TITLE
Add PoolAllocator implementation and tests

### DIFF
--- a/Comb/include/comb/benchmark_slab.cpp
+++ b/Comb/include/comb/benchmark_slab.cpp
@@ -1,0 +1,294 @@
+#include <larvae/larvae.h>
+#include <comb/slab_allocator.h>
+#include <vector>
+
+namespace
+{
+    auto bench1 = larvae::RegisterBenchmark("SlabAllocator", "SmallAllocations_32B", [](larvae::BenchmarkState& state) {
+        comb::SlabAllocator<100000, 16, 32, 64, 128> slabs;
+        std::vector<void*> ptrs;
+        ptrs.reserve(100000);
+
+        while (state.KeepRunning())
+        {
+            void* ptr = slabs.Allocate(32, 8);
+            larvae::DoNotOptimize(ptr);
+            if (ptr)
+            {
+                ptrs.push_back(ptr);
+            }
+
+            if (slabs.GetSlabFreeCount(1) == 0)
+            {
+                for (void* p : ptrs)
+                {
+                    slabs.Deallocate(p);
+                }
+                ptrs.clear();
+            }
+        }
+
+        for (void* ptr : ptrs)
+        {
+            slabs.Deallocate(ptr);
+        }
+    });
+
+    auto bench2 = larvae::RegisterBenchmark("SlabAllocator", "MediumAllocations_128B", [](larvae::BenchmarkState& state) {
+        comb::SlabAllocator<100000, 32, 64, 128, 256> slabs;
+        std::vector<void*> ptrs;
+        ptrs.reserve(100000);
+
+        while (state.KeepRunning())
+        {
+            void* ptr = slabs.Allocate(128, 8);
+            larvae::DoNotOptimize(ptr);
+            if (ptr)
+            {
+                ptrs.push_back(ptr);
+            }
+
+            if (slabs.GetSlabFreeCount(2) == 0)
+            {
+                for (void* p : ptrs)
+                {
+                    slabs.Deallocate(p);
+                }
+                ptrs.clear();
+            }
+        }
+
+        for (void* ptr : ptrs)
+        {
+            slabs.Deallocate(ptr);
+        }
+    });
+
+    auto bench3 = larvae::RegisterBenchmark("SlabAllocator", "MixedSizeAllocations", [](larvae::BenchmarkState& state) {
+        comb::SlabAllocator<100000, 16, 32, 64, 128, 256, 512> slabs;
+        std::vector<void*> ptrs;
+        ptrs.reserve(100000);
+        size_t counter = 0;
+
+        while (state.KeepRunning())
+        {
+            size_t size = 0;
+            switch (counter % 6)
+            {
+                case 0: size = 16; break;
+                case 1: size = 32; break;
+                case 2: size = 64; break;
+                case 3: size = 128; break;
+                case 4: size = 256; break;
+                case 5: size = 512; break;
+            }
+
+            void* ptr = slabs.Allocate(size, 8);
+            larvae::DoNotOptimize(ptr);
+            if (ptr)
+            {
+                ptrs.push_back(ptr);
+            }
+            ++counter;
+
+            if (ptrs.size() >= 50000)
+            {
+                for (void* p : ptrs)
+                {
+                    slabs.Deallocate(p);
+                }
+                ptrs.clear();
+            }
+        }
+
+        for (void* ptr : ptrs)
+        {
+            slabs.Deallocate(ptr);
+        }
+    });
+
+    auto bench4 = larvae::RegisterBenchmark("SlabAllocator", "AllocationAndDeallocation", [](larvae::BenchmarkState& state) {
+        comb::SlabAllocator<100000, 64> slabs;
+
+        while (state.KeepRunning())
+        {
+            void* ptr = slabs.Allocate(64, 8);
+            larvae::DoNotOptimize(ptr);
+            if (ptr)
+            {
+                slabs.Deallocate(ptr);
+            }
+        }
+    });
+
+    auto bench5 = larvae::RegisterBenchmark("SlabAllocator", "RapidRecycling", [](larvae::BenchmarkState& state) {
+        comb::SlabAllocator<10, 64> slabs;
+
+        while (state.KeepRunning())
+        {
+            void* ptrs[10];
+
+            for (int i = 0; i < 10; ++i)
+            {
+                ptrs[i] = slabs.Allocate(64, 8);
+                larvae::DoNotOptimize(ptrs[i]);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                slabs.Deallocate(ptrs[i]);
+            }
+        }
+    });
+
+    auto bench6 = larvae::RegisterBenchmark("SlabAllocator", "ResetPerformance", [](larvae::BenchmarkState& state) {
+        comb::SlabAllocator<10000, 64> slabs;
+        std::vector<void*> ptrs;
+        ptrs.reserve(10000);
+
+        while (state.KeepRunning())
+        {
+            ptrs.clear();
+
+            for (int i = 0; i < 10000; ++i)
+            {
+                void* ptr = slabs.Allocate(64, 8);
+                if (ptr)
+                {
+                    ptrs.push_back(ptr);
+                }
+            }
+
+            slabs.Reset();
+            larvae::DoNotOptimize(ptrs.data());
+        }
+    });
+
+    auto bench7 = larvae::RegisterBenchmark("SlabAllocator", "SlabSelectionOverhead", [](larvae::BenchmarkState& state) {
+        comb::SlabAllocator<100000, 16, 32, 64, 128, 256, 512, 1024, 2048> slabs;
+        std::vector<void*> ptrs;
+        ptrs.reserve(100000);
+        size_t counter = 0;
+
+        while (state.KeepRunning())
+        {
+            size_t size = size_t{16} << (counter % 9);
+            void* ptr = slabs.Allocate(size, 8);
+            larvae::DoNotOptimize(ptr);
+            if (ptr)
+            {
+                ptrs.push_back(ptr);
+            }
+            ++counter;
+
+            if (ptrs.size() >= 50000)
+            {
+                for (void* p : ptrs)
+                {
+                    slabs.Deallocate(p);
+                }
+                ptrs.clear();
+            }
+        }
+
+        for (void* ptr : ptrs)
+        {
+            slabs.Deallocate(ptr);
+        }
+    });
+
+    auto bench8 = larvae::RegisterBenchmark("SlabAllocator", "UnalignedSizes", [](larvae::BenchmarkState& state) {
+        comb::SlabAllocator<100000, 32, 64, 128, 256> slabs;
+        std::vector<void*> ptrs;
+        ptrs.reserve(100000);
+        size_t counter = 0;
+
+        while (state.KeepRunning())
+        {
+            size_t size = 0;
+            switch (counter % 4)
+            {
+                case 0: size = 17; break;
+                case 1: size = 50; break;
+                case 2: size = 100; break;
+                case 3: size = 200; break;
+            }
+
+            void* ptr = slabs.Allocate(size, 8);
+            larvae::DoNotOptimize(ptr);
+            if (ptr)
+            {
+                ptrs.push_back(ptr);
+            }
+            ++counter;
+
+            if (ptrs.size() >= 50000)
+            {
+                for (void* p : ptrs)
+                {
+                    slabs.Deallocate(p);
+                }
+                ptrs.clear();
+            }
+        }
+
+        for (void* ptr : ptrs)
+        {
+            slabs.Deallocate(ptr);
+        }
+    });
+
+    auto bench9 = larvae::RegisterBenchmark("malloc", "MixedSizeAllocations", [](larvae::BenchmarkState& state) {
+        std::vector<void*> ptrs;
+        ptrs.reserve(10000);
+        size_t counter = 0;
+
+        while (state.KeepRunning())
+        {
+            size_t size = 0;
+            switch (counter % 6)
+            {
+                case 0: size = 16; break;
+                case 1: size = 32; break;
+                case 2: size = 64; break;
+                case 3: size = 128; break;
+                case 4: size = 256; break;
+                case 5: size = 512; break;
+            }
+
+            void* ptr = malloc(size);
+            larvae::DoNotOptimize(ptr);
+            if (ptr)
+            {
+                ptrs.push_back(ptr);
+            }
+            ++counter;
+
+            if (ptrs.size() >= 10000)
+            {
+                for (void* p : ptrs)
+                {
+                    free(p);
+                }
+                ptrs.clear();
+            }
+        }
+
+        for (void* ptr : ptrs)
+        {
+            free(ptr);
+        }
+    });
+
+    auto bench10 = larvae::RegisterBenchmark("malloc", "AllocationAndDeallocation", [](larvae::BenchmarkState& state) {
+        while (state.KeepRunning())
+        {
+            void* ptr = malloc(64);
+            larvae::DoNotOptimize(ptr);
+            if (ptr)
+            {
+                free(ptr);
+            }
+        }
+    });
+}

--- a/Comb/include/comb/pool_allocator.h
+++ b/Comb/include/comb/pool_allocator.h
@@ -1,0 +1,524 @@
+#pragma once
+
+#include <comb/allocator_concepts.h>
+#include <hive/core/assert.h>
+#include <comb/platform.h>
+#include <cstddef>
+#include <algorithm>
+#include <cstring>  // For memset
+#include <memory>
+
+// Memory debugging (zero overhead when disabled)
+#if COMB_MEM_DEBUG
+    #include <comb/debug/mem_debug_config.h>
+    #include <comb/debug/allocation_registry.h>
+    #include <comb/debug/allocation_history.h>
+    #include <comb/debug/global_memory_tracker.h>
+    #include <comb/debug/platform_utils.h>
+    #include <hive/core/log.h>
+    #include <comb/combmodule.h>
+#endif
+
+namespace comb
+{
+    /**
+     * Pool allocator for fixed-size objects with free-list recycling
+     *
+     * Pre-allocates a pool of N objects of type T and manages them via free-list.
+     * Provides ultra-fast O(1) allocation and deallocation with memory reuse.
+     * Perfect for ECS entities, components, particles, and other fixed-size objects.
+     *
+     * Satisfies the comb::Allocator concept.
+     *
+     * Use cases:
+     * - ECS entities and components (fixed types)
+     * - Particle systems (allocate/free particles constantly)
+     * - Object pools for frequently created/destroyed objects
+     * - Game objects with predictable lifecycle
+     *
+     * Memory layout:
+     * ┌────────────────────────────────────────────────────┐
+     * │ [Object 0][Object 1][Object 2]...[Object N-1]      │
+     * │    ↓         ↓         ↓                           │
+     * │  free    in-use     free                           │
+     * │    │                  │                            │
+     * │    └──────────────────┘                            │
+     * │  (free-list links free objects together)           │
+     * └────────────────────────────────────────────────────┘
+     *
+     * Free-list mechanism:
+     * - Each free slot stores a pointer to next free slot
+     * - Allocation: pop from free-list head (O(1))
+     * - Deallocation: push to free-list head (O(1))
+     * - No fragmentation (all objects same size)
+     *
+     * Performance characteristics:
+     * - Allocation: O(1) - pop from free-list
+     * - Deallocation: O(1) - push to free-list
+     * - Reset: O(1) - rebuild free-list
+     * - Thread-safe: No (use per-thread pools or add mutex)
+     * - Fragmentation: None (fixed-size objects)
+     *
+     * Limitations:
+     * - Fixed object size (one pool per type)
+     * - Fixed capacity (set at construction)
+     * - Returns nullptr when pool exhausted (no hidden allocations)
+     * - Not thread-safe (use PoolAllocator per thread or add synchronization)
+     *
+     * Example:
+     * @code
+     *   // Create pool for 1000 Enemy objects
+     *   comb::PoolAllocator<Enemy> enemyPool{1000};
+     *
+     *   // Allocate enemy (O(1))
+     *   Enemy* enemy = comb::New<Enemy>(enemyPool, health, position);
+     *   if (!enemy) {
+     *       // Pool exhausted - handle error
+     *       return;
+     *   }
+     *
+     *   // Use enemy...
+     *
+     *   // Free enemy - returns to free-list (O(1))
+     *   comb::Delete(enemyPool, enemy);
+     *
+     *   // Memory immediately available for reuse!
+     *   Enemy* another = comb::New<Enemy>(enemyPool); // Reuses freed memory
+     *
+     *   // Reset pool - frees all objects
+     *   enemyPool.Reset();
+     * @endcode
+     */
+    template<typename T>
+    class PoolAllocator
+    {
+    public:
+        /**
+         * Construct pool allocator with capacity for N objects
+         * @param capacity Number of objects to pre-allocate
+         */
+        explicit PoolAllocator(size_t capacity)
+            : capacity_{capacity}
+            , used_count_{0}
+        {
+            hive::Assert(capacity > 0, "Pool capacity must be > 0");
+
+            constexpr size_t base_slot_size = (sizeof(T) > sizeof(void*)) ? sizeof(T) : sizeof(void*);
+
+#if COMB_MEM_DEBUG
+            constexpr size_t slot_size = base_slot_size + debug::TotalGuardSize;
+#else
+            constexpr size_t slot_size = base_slot_size;
+#endif
+
+            total_size_ = capacity * slot_size;
+            memory_block_ = AllocatePages(total_size_);
+            hive::Assert(memory_block_ != nullptr, "Failed to allocate pool memory");
+
+            Reset();
+
+#if COMB_MEM_DEBUG
+            registry_ = std::make_unique<debug::AllocationRegistry>();
+            history_ = std::make_unique<debug::AllocationHistory>();
+            debug::GlobalMemoryTracker::GetInstance().RegisterAllocator(GetName(), registry_.get());
+#endif
+        }
+
+        ~PoolAllocator()
+        {
+#if COMB_MEM_DEBUG
+            if (registry_)
+            {
+                if constexpr (debug::kLeakDetectionEnabled)
+                {
+                    registry_->ReportLeaks(GetName());
+                }
+                debug::GlobalMemoryTracker::GetInstance().UnregisterAllocator(registry_.get());
+            }
+#endif
+
+            if (memory_block_)
+            {
+                FreePages(memory_block_, total_size_);
+            }
+        }
+
+        PoolAllocator(const PoolAllocator&) = delete;
+        PoolAllocator& operator=(const PoolAllocator&) = delete;
+
+        PoolAllocator(PoolAllocator&& other) noexcept
+            : memory_block_{other.memory_block_}
+            , free_list_head_{other.free_list_head_}
+            , capacity_{other.capacity_}
+            , used_count_{other.used_count_}
+            , total_size_{other.total_size_}
+#if COMB_MEM_DEBUG
+            , registry_{std::move(other.registry_)}
+            , history_{std::move(other.history_)}
+#endif
+        {
+            other.memory_block_ = nullptr;
+            other.free_list_head_ = nullptr;
+            other.capacity_ = 0;
+            other.used_count_ = 0;
+            other.total_size_ = 0;
+        }
+
+        PoolAllocator& operator=(PoolAllocator&& other) noexcept
+        {
+            if (this != &other)
+            {
+#if COMB_MEM_DEBUG
+                if (registry_)
+                {
+                    if constexpr (debug::kLeakDetectionEnabled)
+                    {
+                        registry_->ReportLeaks(GetName());
+                    }
+                    debug::GlobalMemoryTracker::GetInstance().UnregisterAllocator(registry_.get());
+                }
+#endif
+
+                if (memory_block_)
+                {
+                    FreePages(memory_block_, total_size_);
+                }
+
+                memory_block_ = other.memory_block_;
+                free_list_head_ = other.free_list_head_;
+                capacity_ = other.capacity_;
+                used_count_ = other.used_count_;
+                total_size_ = other.total_size_;
+
+#if COMB_MEM_DEBUG
+                registry_ = std::move(other.registry_);
+                history_ = std::move(other.history_);
+#endif
+
+                other.memory_block_ = nullptr;
+                other.free_list_head_ = nullptr;
+                other.capacity_ = 0;
+                other.used_count_ = 0;
+                other.total_size_ = 0;
+            }
+            return *this;
+        }
+
+        /**
+         * Allocate memory for one object from the pool
+         * Pops from free-list (O(1))
+         *
+         * @param size Number of bytes (must be <= sizeof(T), ignored)
+         * @param alignment Required alignment (must be <= alignof(T), ignored)
+         * @param tag Optional allocation tag for debugging (e.g., "Enemy #42")
+         * @return Pointer to memory, or nullptr if pool exhausted
+         *
+         * Note: size and alignment parameters required by Allocator concept,
+         * but ignored since pool only handles T-sized objects.
+         * tag parameter is zero-cost when COMB_MEM_DEBUG=0.
+         */
+        [[nodiscard]] void* Allocate(size_t size, size_t alignment, const char* tag = nullptr)
+        {
+#if COMB_MEM_DEBUG
+            return AllocateDebug(size, alignment, tag);
+#else
+            (void)tag;  // Suppress unused warning
+
+            hive::Assert(size <= sizeof(T), "PoolAllocator can only allocate sizeof(T) bytes");
+            hive::Assert(alignment <= alignof(T), "PoolAllocator alignment limited to alignof(T)");
+
+            if (!free_list_head_)
+            {
+                return nullptr;
+            }
+
+            void* ptr = free_list_head_;
+            free_list_head_ = *static_cast<void**>(free_list_head_);
+            ++used_count_;
+
+            return ptr;
+#endif
+        }
+
+        /**
+         * Deallocate memory back to the pool
+         * Pushes to free-list (O(1))
+         *
+         * @param ptr Pointer to deallocate (can be nullptr)
+         *
+         * IMPORTANT: Pointer must have been allocated from THIS pool.
+         * No validation is performed - deallocating wrong pointer is undefined behavior.
+         */
+        void Deallocate(void* ptr)
+        {
+#if COMB_MEM_DEBUG
+            DeallocateDebug(ptr);
+#else
+            if (!ptr)
+                return;
+
+            hive::Assert(used_count_ > 0, "Deallocate called more times than Allocate");
+
+            *static_cast<void**>(ptr) = free_list_head_;
+            free_list_head_ = ptr;
+            --used_count_;
+#endif
+        }
+
+        /**
+         * Reset pool - marks all objects as free
+         * Rebuilds free-list to initial state
+         * Does NOT call destructors on objects!
+         */
+        void Reset()
+        {
+            constexpr size_t base_slot_size = (sizeof(T) > sizeof(void*)) ? sizeof(T) : sizeof(void*);
+
+#if COMB_MEM_DEBUG
+            // Debug mode: slots include guard bytes
+            constexpr size_t slot_size = base_slot_size + debug::TotalGuardSize;
+            constexpr size_t guard_offset = debug::GuardSize;
+#else
+            constexpr size_t slot_size = base_slot_size;
+            constexpr size_t guard_offset = 0;
+#endif
+
+            auto* current = static_cast<std::byte*>(memory_block_) + guard_offset;
+            free_list_head_ = current;
+
+            for (size_t i = 0; i < capacity_ - 1; ++i)
+            {
+                auto* next = current + slot_size;
+                *reinterpret_cast<void**>(current) = next;
+                current = next;
+            }
+
+            *reinterpret_cast<void**>(current) = nullptr;
+
+            used_count_ = 0;
+
+#if COMB_MEM_DEBUG
+            if (registry_)
+            {
+                registry_->Clear();
+            }
+#endif
+        }
+
+        /**
+         * Get number of objects currently allocated
+         * @return Number of objects in use
+         */
+        [[nodiscard]] size_t GetUsedMemory() const
+        {
+            return used_count_ * sizeof(T);
+        }
+
+        /**
+         * Get total capacity of pool
+         * @return Total bytes for all objects
+         */
+        [[nodiscard]] size_t GetTotalMemory() const
+        {
+            return capacity_ * sizeof(T);
+        }
+
+        /**
+         * Get allocator name for debugging
+         * @return "PoolAllocator"
+         */
+        [[nodiscard]] const char* GetName() const
+        {
+            return "PoolAllocator";
+        }
+
+        /**
+         * Get pool capacity
+         * @return Maximum number of objects
+         */
+        [[nodiscard]] size_t GetCapacity() const
+        {
+            return capacity_;
+        }
+
+        /**
+         * Get number of objects currently in use
+         * @return Number of allocated objects
+         */
+        [[nodiscard]] size_t GetUsedCount() const
+        {
+            return used_count_;
+        }
+
+        /**
+         * Get number of free slots available
+         * @return Number of objects that can still be allocated
+         */
+        [[nodiscard]] size_t GetFreeCount() const
+        {
+            return capacity_ - used_count_;
+        }
+
+    private:
+        void* memory_block_{nullptr};      // Pre-allocated memory block
+        void* free_list_head_{nullptr};    // Head of free-list
+        size_t capacity_{0};               // Total number of objects
+        size_t used_count_{0};             // Number of objects currently allocated
+        size_t total_size_{0};             // Total size in bytes (for FreePages)
+
+#if COMB_MEM_DEBUG
+        // Debug tracking (zero overhead when COMB_MEM_DEBUG=0)
+        void* AllocateDebug(size_t size, size_t alignment, const char* tag);
+        void DeallocateDebug(void* ptr);
+
+        // Use unique_ptr to enable move semantics (AllocationRegistry contains non-movable mutex)
+        std::unique_ptr<debug::AllocationRegistry> registry_;
+        std::unique_ptr<debug::AllocationHistory> history_;
+#endif
+    };
+
+    template<typename T>
+    concept ValidPoolAllocator = Allocator<PoolAllocator<T>>;
+
+#if COMB_MEM_DEBUG
+    // ========================================================================
+    // Debug Implementation (Template methods - must be in header)
+    // ========================================================================
+
+    template<typename T>
+    void* PoolAllocator<T>::AllocateDebug(size_t size, size_t alignment, const char* tag)
+    {
+        using namespace debug;
+
+        hive::Assert(size <= sizeof(T), "PoolAllocator can only allocate sizeof(T) bytes");
+        hive::Assert(alignment <= alignof(T), "PoolAllocator alignment limited to alignof(T)");
+
+        // Pool exhausted - check BEFORE adding guard bytes
+        if (!free_list_head_)
+        {
+            hive::LogError(comb::LogCombRoot,
+                           "[MEM_DEBUG] [{}] Pool exhausted: size={}, capacity={}, tag={}",
+                           GetName(), sizeof(T), capacity_, tag ? tag : "<no tag>");
+            return nullptr;
+        }
+
+        // 1. Pop from free-list
+        // In debug mode, free_list_head_ points to user data area (after guard)
+        void* userPtr = free_list_head_;
+        free_list_head_ = *static_cast<void**>(userPtr);
+        ++used_count_;
+
+        // 2. Add guard bytes (in-place within the pool slot)
+        // Layout: [GUARD_FRONT (4B)][user data (sizeof(T))][GUARD_BACK (4B)]
+        // Note: Pool slots are already sized for this in debug builds
+
+        const size_t guardSize = sizeof(uint32_t);
+        void* rawPtr = static_cast<std::byte*>(userPtr) - guardSize;
+
+        auto* guardFront = static_cast<uint32_t*>(rawPtr);
+        *guardFront = GuardMagic;
+
+        auto* guardBack = reinterpret_cast<uint32_t*>(
+            static_cast<std::byte*>(userPtr) + sizeof(T)
+        );
+        *guardBack = GuardMagic;
+
+        // 3. Initialize memory with pattern (detect uninitialized reads)
+        if constexpr (kMemDebugEnabled)
+        {
+            std::memset(userPtr, AllocatedMemoryPattern, sizeof(T));
+        }
+
+        // 4. Register allocation
+        AllocationInfo info{};
+        info.address = userPtr;
+        info.size = sizeof(T);
+        info.alignment = alignof(T);
+        info.timestamp = GetTimestamp();
+        info.tag = tag;
+        info.allocationId = registry_->GetNextAllocationId();
+        info.threadId = GetThreadId();
+
+#if COMB_MEM_DEBUG_CALLSTACKS
+        CaptureCallstack(info.callstack, info.callstackDepth);
+#endif
+
+        registry_->RegisterAllocation(info);
+
+        // 5. Record in history
+#if COMB_MEM_DEBUG_HISTORY
+        history_->RecordAllocation(info);
+#endif
+
+        return userPtr;
+    }
+
+    template<typename T>
+    void PoolAllocator<T>::DeallocateDebug(void* ptr)
+    {
+        using namespace debug;
+
+        if (!ptr) return;
+
+        // 1. Find allocation info
+        auto* info = registry_->FindAllocation(ptr);
+        if (!info)
+        {
+            hive::LogError(comb::LogCombRoot,
+                           "[MEM_DEBUG] [{}] Double-free or invalid pointer detected! Address: {}",
+                           GetName(), ptr);
+            hive::Assert(false, "Double-free or invalid pointer (not found in registry)");
+            return;
+        }
+
+        // 2. Check guard bytes
+        if constexpr (kMemDebugEnabled)
+        {
+            if (!info->CheckGuards())
+            {
+                auto* guardFront = info->GetGuardFront();
+                auto* guardBack = info->GetGuardBack();
+
+                if (*guardFront != GuardMagic)
+                {
+                    hive::LogError(comb::LogCombRoot,
+                                   "[MEM_DEBUG] [{}] Buffer UNDERRUN detected! Address: {}, Size: {}, Tag: {}",
+                                   GetName(), ptr, info->size, info->GetTagOrDefault());
+                    hive::Assert(false, "Buffer underrun detected");
+                }
+
+                if (*guardBack != GuardMagic)
+                {
+                    hive::LogError(comb::LogCombRoot,
+                                   "[MEM_DEBUG] [{}] Buffer OVERRUN detected! Address: {}, Size: {}, Tag: {}",
+                                   GetName(), ptr, info->size, info->GetTagOrDefault());
+                    hive::Assert(false, "Buffer overrun detected");
+                }
+            }
+        }
+
+        // 3. Fill with freed pattern (detect use-after-free)
+#if COMB_MEM_DEBUG_USE_AFTER_FREE
+        std::memset(ptr, FreedMemoryPattern, sizeof(T));
+#endif
+
+        // 4. Record deallocation in history
+#if COMB_MEM_DEBUG_HISTORY
+        history_->RecordDeallocation(ptr, sizeof(T));
+#endif
+
+        // 5. Unregister allocation
+        registry_->UnregisterAllocation(ptr);
+
+        // 6. Return to free-list
+        // In debug mode, free-list stores pointers in user data area (not in guards)
+        hive::Assert(used_count_ > 0, "Deallocate called more times than Allocate");
+
+        // Push to free-list head (ptr is already userPtr in debug mode)
+        *static_cast<void**>(ptr) = free_list_head_;
+        free_list_head_ = ptr;
+        --used_count_;
+    }
+
+#endif // COMB_MEM_DEBUG
+}

--- a/Comb/include/comb/slab_allocator.h
+++ b/Comb/include/comb/slab_allocator.h
@@ -1,0 +1,693 @@
+#pragma once
+
+#include <comb/allocator_concepts.h>
+#include <hive/core/assert.h>
+#include <comb/utils.h>
+#include <comb/platform.h>
+#include <cstddef>
+#include <array>
+#include <memory>
+
+// Memory debugging (zero overhead when disabled)
+#if COMB_MEM_DEBUG
+    #include <comb/debug/mem_debug_config.h>
+    #include <comb/debug/allocation_registry.h>
+    #include <comb/debug/allocation_history.h>
+    #include <comb/debug/global_memory_tracker.h>
+    #include <comb/debug/platform_utils.h>
+    #include <hive/core/log.h>
+    #include <comb/combmodule.h>
+    #include <cstring>  // For memset
+#endif
+
+namespace comb
+{
+    /**
+     * Slab allocator with multiple size classes and free-lists
+     *
+     * Manages multiple "slabs" (pools) of different object sizes.
+     * Each slab is a PoolAllocator for a specific size class.
+     * Allocations are routed to the smallest slab that can fit the request.
+     *
+     * Satisfies the comb::Allocator concept.
+     *
+     * Use cases:
+     * - General-purpose allocation with known size distribution
+     * - Multiple object types with different sizes
+     * - Need fast allocation + deallocation with memory reuse
+     * - Alternative to malloc with better performance
+     *
+     * Memory layout (example with 3 size classes: 32, 64, 128):
+     * ┌──────────────────────────────────────────────────────┐
+     * │ Slab 0 (32B):  [obj][obj][obj]...[obj] + free-list   │
+     * │ Slab 1 (64B):  [obj][obj][obj]...[obj] + free-list   │
+     * │ Slab 2 (128B): [obj][obj][obj]...[obj] + free-list   │
+     * └──────────────────────────────────────────────────────┘
+     *
+     * Each slab operates independently with its own free-list.
+     *
+     * Performance characteristics:
+     * - Allocation: O(1) - find slab O(K) + pop from free-list O(1), K = size classes
+     * - Deallocation: O(1) - push to free-list
+     * - Typical K = 8-16 size classes (small overhead)
+     * - Thread-safe: No (use per-thread or add synchronization)
+     * - Fragmentation: None (pre-allocated slabs)
+     *
+     * Limitations:
+     * - Fixed size classes (set at compile time)
+     * - Fixed capacity per slab
+     * - Returns nullptr when slab exhausted (no hidden allocations)
+     * - Not thread-safe by default
+     *
+     * Size class selection:
+     * - Sizes are rounded up to next power of 2
+     * - Common pattern: 16, 32, 64, 128, 256, 512, 1024, 2048
+     * - Should cover 95% of your allocation sizes
+     *
+     * Example:
+     * @code
+     *   // Create slab allocator with 1000 objects per size class
+     *   // Size classes: 32, 64, 128, 256, 512 bytes
+     *   comb::SlabAllocator<1000, 32, 64, 128, 256, 512> slabs;
+     *
+     *   // Allocate 60 bytes - routed to 64-byte slab
+     *   void* ptr1 = slabs.Allocate(60, 8);
+     *   if (!ptr1) {
+     *       // 64-byte slab exhausted
+     *       return;
+     *   }
+     *
+     *   // Allocate 200 bytes - routed to 256-byte slab
+     *   void* ptr2 = slabs.Allocate(200, 8);
+     *
+     *   // Free memory - returns to appropriate free-list
+     *   slabs.Deallocate(ptr1);  // Returns to 64-byte slab
+     *   slabs.Deallocate(ptr2);  // Returns to 256-byte slab
+     *
+     *   // Memory immediately available for reuse
+     *   void* ptr3 = slabs.Allocate(60, 8);  // Reuses ptr1's slot
+     *
+     *   // Reset all slabs at once
+     *   slabs.Reset();
+     * @endcode
+     */
+    template<size_t ObjectsPerSlab, size_t... SizeClasses>
+    class SlabAllocator
+    {
+        static_assert(sizeof...(SizeClasses) > 0, "Must provide at least one size class");
+        static_assert(ObjectsPerSlab > 0, "Must allocate at least one object per slab");
+
+    private:
+        // Size classes rounded to powers of 2 and sorted
+        static constexpr auto sizes_ = MakeArray(NextPowerOfTwo(SizeClasses)...);
+        static_assert(IsSorted(sizes_), "Size classes must be sorted");
+
+        static constexpr size_t NumSlabs = sizeof...(SizeClasses);
+
+        // Each slab: memory block + free-list head + usage counter
+        struct Slab
+        {
+            void* memory_block{nullptr};
+            void* free_list_head{nullptr};
+            size_t used_count{0};
+            size_t slot_size{0};
+            size_t total_size{0};
+            size_t free_list_offset_{0};  // Track offset for Reset()
+            size_t user_size_{0};  // Track user-visible size (without guard bytes)
+
+            void Initialize(size_t size, size_t free_list_offset = 0)
+            {
+                slot_size = size;
+                total_size = ObjectsPerSlab * slot_size;
+                free_list_offset_ = free_list_offset;
+
+                // Calculate user size (slot_size minus guard bytes in debug mode)
+#if COMB_MEM_DEBUG
+                user_size_ = size - debug::TotalGuardSize;
+#else
+                user_size_ = size;
+#endif
+
+                // Allocate memory from OS
+                memory_block = AllocatePages(total_size);
+                hive::Assert(memory_block != nullptr, "Failed to allocate slab memory");
+
+                // Build free-list (with optional offset for debug guard bytes)
+                RebuildFreeList(free_list_offset);
+            }
+
+            void Destroy()
+            {
+                if (memory_block)
+                {
+                    FreePages(memory_block, total_size);
+                    memory_block = nullptr;
+                    free_list_head = nullptr;
+                }
+            }
+
+            void RebuildFreeList(size_t free_list_offset)
+            {
+                // In debug mode, free_list_offset skips the guard bytes at the start of each slot
+                char* current = static_cast<char*>(memory_block) + free_list_offset;
+                free_list_head = current;
+
+                for (size_t i = 0; i < ObjectsPerSlab - 1; ++i)
+                {
+                    char* next = current + slot_size;
+                    *reinterpret_cast<void**>(current) = next;
+                    current = next;
+                }
+
+                *reinterpret_cast<void**>(current) = nullptr;
+                used_count = 0;
+            }
+
+            void RebuildFreeList()
+            {
+                // Use stored offset from Initialize()
+                RebuildFreeList(free_list_offset_);
+            }
+
+            void* Allocate()
+            {
+                if (!free_list_head)
+                {
+                    return nullptr;
+                }
+
+                void* ptr = free_list_head;
+                free_list_head = *static_cast<void**>(free_list_head);
+                ++used_count;
+                return ptr;
+            }
+
+            void Deallocate(void* ptr)
+            {
+                if (!ptr)
+                    return;
+
+                hive::Assert(used_count > 0, "Deallocate called more than Allocate");
+
+                *static_cast<void**>(ptr) = free_list_head;
+                free_list_head = ptr;
+                --used_count;
+            }
+
+            bool Contains(void* ptr) const
+            {
+                if (!ptr || !memory_block)
+                    return false;
+
+                const char* start = static_cast<const char*>(memory_block);
+                const char* end = start + (ObjectsPerSlab * slot_size);
+                const char* p = static_cast<const char*>(ptr);
+
+                return p >= start && p < end;
+            }
+
+            size_t GetUsedMemory() const
+            {
+                // Return user-visible memory (excluding guard bytes)
+                return used_count * user_size_;
+            }
+
+            size_t GetTotalMemory() const
+            {
+                // Return user-visible capacity (excluding guard bytes)
+                return ObjectsPerSlab * user_size_;
+            }
+
+            size_t GetFreeCount() const
+            {
+                return ObjectsPerSlab - used_count;
+            }
+        };
+
+        std::array<Slab, NumSlabs> slabs_{};
+
+        // Find slab index for given size
+        constexpr size_t FindSlabIndex(size_t size) const
+        {
+            for (size_t i = 0; i < sizes_.size(); ++i)
+            {
+                if (size <= sizes_[i])
+                {
+                    return i;
+                }
+            }
+            return NumSlabs;  // No slab large enough
+        }
+
+    public:
+        SlabAllocator(const SlabAllocator&) = delete;
+        SlabAllocator& operator=(const SlabAllocator&) = delete;
+
+        /**
+         * Construct slab allocator and initialize all slabs
+         */
+        SlabAllocator()
+        {
+            for (size_t i = 0; i < NumSlabs; ++i)
+            {
+#if COMB_MEM_DEBUG
+                // Debug mode: slots need extra space for guard bytes
+                // Free-list starts after the front guard
+                slabs_[i].Initialize(sizes_[i] + debug::TotalGuardSize, debug::GuardSize);
+#else
+                slabs_[i].Initialize(sizes_[i]);
+#endif
+            }
+
+#if COMB_MEM_DEBUG
+            // Create debug tracking objects
+            registry_ = std::make_unique<debug::AllocationRegistry>();
+            history_ = std::make_unique<debug::AllocationHistory>();
+
+            // Register with global tracker
+            debug::GlobalMemoryTracker::GetInstance().RegisterAllocator(GetName(), registry_.get());
+#endif
+        }
+
+        /**
+         * Destructor - frees all slab memory
+         */
+        ~SlabAllocator()
+        {
+#if COMB_MEM_DEBUG
+            if (registry_)
+            {
+                // Report leaks before destruction
+                if constexpr (debug::kLeakDetectionEnabled)
+                {
+                    registry_->ReportLeaks(GetName());
+                }
+
+                // Unregister from global tracker
+                debug::GlobalMemoryTracker::GetInstance().UnregisterAllocator(registry_.get());
+            }
+#endif
+
+            for (auto& slab : slabs_)
+            {
+                slab.Destroy();
+            }
+        }
+
+        /**
+         * Move constructor
+         *
+         * Transfers ownership of memory blocks and debug tracking to new allocator.
+         * All allocations made before move can still be deallocated from moved-to allocator.
+         */
+        SlabAllocator(SlabAllocator&& other) noexcept
+            : slabs_{std::move(other.slabs_)}
+#if COMB_MEM_DEBUG
+            , registry_{std::move(other.registry_)}
+            , history_{std::move(other.history_)}
+#endif
+        {
+            // Note: registry_ and history_ are automatically moved via unique_ptr
+            // No need to update global tracker - it still points to the same registry object
+
+            // Invalidate other
+            for (auto& slab : other.slabs_)
+            {
+                slab.memory_block = nullptr;
+                slab.free_list_head = nullptr;
+                slab.used_count = 0;
+            }
+        }
+
+        SlabAllocator& operator=(SlabAllocator&& other) noexcept
+        {
+            if (this != &other)
+            {
+#if COMB_MEM_DEBUG
+                if (registry_)
+                {
+                    // Report leaks for our current allocations before we destroy them
+                    if constexpr (debug::kLeakDetectionEnabled)
+                    {
+                        registry_->ReportLeaks(GetName());
+                    }
+
+                    // Unregister from global tracker
+                    debug::GlobalMemoryTracker::GetInstance().UnregisterAllocator(registry_.get());
+                }
+#endif
+
+                // Destroy our slabs
+                for (auto& slab : slabs_)
+                {
+                    slab.Destroy();
+                }
+
+                // Move from other
+                slabs_ = std::move(other.slabs_);
+
+#if COMB_MEM_DEBUG
+                // Move the debug tracking objects
+                registry_ = std::move(other.registry_);
+                history_ = std::move(other.history_);
+                // No need to re-register - global tracker still points to same registry object
+#endif
+
+                // Invalidate other
+                for (auto& slab : other.slabs_)
+                {
+                    slab.memory_block = nullptr;
+                    slab.free_list_head = nullptr;
+                    slab.used_count = 0;
+                }
+            }
+            return *this;
+        }
+
+        /**
+         * Allocate memory from appropriate slab
+         *
+         * @param size Number of bytes to allocate
+         * @param alignment Required alignment (must be <= alignof(std::max_align_t))
+         * @param tag Optional allocation tag for debugging (e.g., "Entity #42")
+         * @return Pointer to allocated memory, or nullptr if:
+         *         - No slab can fit the requested size
+         *         - Appropriate slab is exhausted
+         *
+         * Note: tag parameter is zero-cost when COMB_MEM_DEBUG=0
+         *
+         * IMPORTANT: Does NOT fallback to operator new. Returns nullptr when out of memory.
+         */
+        [[nodiscard]] void* Allocate(size_t size, size_t alignment, const char* tag = nullptr)
+        {
+#if COMB_MEM_DEBUG
+            return AllocateDebug(size, alignment, tag);
+#else
+            (void)tag;  // Suppress unused warning
+
+            hive::Assert(alignment <= alignof(std::max_align_t),
+                         "SlabAllocator alignment limited to max_align_t");
+
+            const size_t slab_index = FindSlabIndex(size);
+
+            // No slab large enough
+            if (slab_index >= NumSlabs)
+            {
+                return nullptr;
+            }
+
+            return slabs_[slab_index].Allocate();
+#endif
+        }
+
+        /**
+         * Deallocate memory back to appropriate slab
+         *
+         * @param ptr Pointer to deallocate (can be nullptr)
+         *
+         * IMPORTANT: Pointer must have been allocated from THIS allocator.
+         * Finds which slab owns the pointer and returns it to that slab's free-list.
+         */
+        void Deallocate(void* ptr)
+        {
+#if COMB_MEM_DEBUG
+            DeallocateDebug(ptr);
+#else
+            if (!ptr)
+                return;
+
+            // Find which slab owns this pointer
+            for (auto& slab : slabs_)
+            {
+                if (slab.Contains(ptr))
+                {
+                    slab.Deallocate(ptr);
+                    return;
+                }
+            }
+
+            // Pointer not from any slab - error
+            hive::Assert(false, "Pointer not allocated from this SlabAllocator");
+#endif
+        }
+
+        /**
+         * Reset all slabs - marks all memory as free
+         * Rebuilds free-lists for all slabs
+         */
+        void Reset()
+        {
+            for (auto& slab : slabs_)
+            {
+                slab.RebuildFreeList();
+            }
+
+#if COMB_MEM_DEBUG
+            // Clear debug tracking registry
+            if (registry_)
+            {
+                registry_->Clear();
+            }
+#endif
+        }
+
+        /**
+         * Get total bytes currently allocated across all slabs
+         */
+        [[nodiscard]] size_t GetUsedMemory() const
+        {
+            size_t total = 0;
+            for (const auto& slab : slabs_)
+            {
+                total += slab.GetUsedMemory();
+            }
+            return total;
+        }
+
+        /**
+         * Get total capacity across all slabs
+         */
+        [[nodiscard]] size_t GetTotalMemory() const
+        {
+            size_t total = 0;
+            for (const auto& slab : slabs_)
+            {
+                total += slab.GetTotalMemory();
+            }
+            return total;
+        }
+
+        /**
+         * Get allocator name for debugging
+         */
+        [[nodiscard]] const char* GetName() const
+        {
+            return "SlabAllocator";
+        }
+
+        /**
+         * Get number of size classes
+         */
+        [[nodiscard]] constexpr size_t GetSlabCount() const
+        {
+            return NumSlabs;
+        }
+
+        /**
+         * Get size classes array
+         */
+        [[nodiscard]] constexpr auto GetSizeClasses() const
+        {
+            return sizes_;
+        }
+
+        /**
+         * Get usage stats for a specific slab
+         */
+        [[nodiscard]] size_t GetSlabUsedCount(size_t slab_index) const
+        {
+            hive::Assert(slab_index < NumSlabs, "Slab index out of range");
+            return slabs_[slab_index].used_count;
+        }
+
+        /**
+         * Get free count for a specific slab
+         */
+        [[nodiscard]] size_t GetSlabFreeCount(size_t slab_index) const
+        {
+            hive::Assert(slab_index < NumSlabs, "Slab index out of range");
+            return slabs_[slab_index].GetFreeCount();
+        }
+
+#if COMB_MEM_DEBUG
+    private:
+        // Debug tracking (zero overhead when COMB_MEM_DEBUG=0)
+        void* AllocateDebug(size_t size, size_t alignment, const char* tag);
+        void DeallocateDebug(void* ptr);
+
+        // Use unique_ptr to enable move semantics (AllocationRegistry contains non-movable mutex)
+        std::unique_ptr<debug::AllocationRegistry> registry_;
+        std::unique_ptr<debug::AllocationHistory> history_;
+#endif
+    };
+
+    template<size_t N, size_t... Sizes>
+    concept ValidSlabAllocator = Allocator<SlabAllocator<N, Sizes...>>;
+
+#if COMB_MEM_DEBUG
+    // ========================================================================
+    // Debug Implementation (Template methods - must be in header)
+    // ========================================================================
+
+    template<size_t ObjectsPerSlab, size_t... SizeClasses>
+    void* SlabAllocator<ObjectsPerSlab, SizeClasses...>::AllocateDebug(size_t size, size_t alignment, const char* tag)
+    {
+        using namespace debug;
+
+        hive::Assert(alignment <= alignof(std::max_align_t),
+                     "SlabAllocator alignment limited to max_align_t");
+
+        const size_t slab_index = FindSlabIndex(size);
+
+        // No slab large enough - check BEFORE adding guard bytes
+        if (slab_index >= NumSlabs)
+        {
+            hive::LogError(comb::LogCombRoot,
+                           "[MEM_DEBUG] [{}] No slab can fit size={}, max_size={}, tag={}",
+                           GetName(), size, sizes_[NumSlabs - 1], tag ? tag : "<no tag>");
+            return nullptr;
+        }
+
+        // Get actual slot size for this slab
+        const size_t slotSize = sizes_[slab_index];
+
+        // 1. Pop from slab free-list
+        // In debug mode, Allocate() returns a pointer after the guard front
+        void* userPtr = slabs_[slab_index].Allocate();
+        if (!userPtr)
+        {
+            hive::LogError(comb::LogCombRoot,
+                           "[MEM_DEBUG] [{}] Slab {} (size={}) exhausted: requested size={}, tag={}",
+                           GetName(), slab_index, slotSize, size, tag ? tag : "<no tag>");
+            return nullptr;
+        }
+
+        // 2. Add guard bytes in-place within the slab slot
+        // Layout: [GUARD_FRONT (4B)][user data (size)][GUARD_BACK (4B)]
+        const size_t guardSize = sizeof(uint32_t);
+        void* rawPtr = static_cast<std::byte*>(userPtr) - guardSize;
+
+        auto* guardFront = static_cast<uint32_t*>(rawPtr);
+        *guardFront = GuardMagic;
+
+        auto* guardBack = reinterpret_cast<uint32_t*>(
+            static_cast<std::byte*>(userPtr) + size
+        );
+        *guardBack = GuardMagic;
+
+        // 3. Initialize memory with pattern (detect uninitialized reads)
+        if constexpr (kMemDebugEnabled)
+        {
+            std::memset(userPtr, AllocatedMemoryPattern, size);
+        }
+
+        // 4. Register allocation
+        AllocationInfo info{};
+        info.address = userPtr;
+        info.size = size;
+        info.alignment = alignment;
+        info.timestamp = GetTimestamp();
+        info.tag = tag;
+        info.allocationId = registry_->GetNextAllocationId();
+        info.threadId = GetThreadId();
+
+#if COMB_MEM_DEBUG_CALLSTACKS
+        CaptureCallstack(info.callstack, info.callstackDepth);
+#endif
+
+        registry_->RegisterAllocation(info);
+
+        // 5. Record in history
+#if COMB_MEM_DEBUG_HISTORY
+        history_->RecordAllocation(info);
+#endif
+
+        return userPtr;
+    }
+
+    template<size_t ObjectsPerSlab, size_t... SizeClasses>
+    void SlabAllocator<ObjectsPerSlab, SizeClasses...>::DeallocateDebug(void* ptr)
+    {
+        using namespace debug;
+
+        if (!ptr) return;
+
+        // 1. Find allocation info
+        auto* info = registry_->FindAllocation(ptr);
+        if (!info)
+        {
+            hive::LogError(comb::LogCombRoot,
+                           "[MEM_DEBUG] [{}] Double-free or invalid pointer detected! Address: {}",
+                           GetName(), ptr);
+            hive::Assert(false, "Double-free or invalid pointer (not found in registry)");
+            return;
+        }
+
+        // 2. Check guard bytes
+        if constexpr (kMemDebugEnabled)
+        {
+            if (!info->CheckGuards())
+            {
+                auto* guardFront = info->GetGuardFront();
+                auto* guardBack = info->GetGuardBack();
+
+                if (*guardFront != GuardMagic)
+                {
+                    hive::LogError(comb::LogCombRoot,
+                                   "[MEM_DEBUG] [{}] Buffer UNDERRUN detected! Address: {}, Size: {}, Tag: {}",
+                                   GetName(), ptr, info->size, info->GetTagOrDefault());
+                    hive::Assert(false, "Buffer underrun detected");
+                }
+
+                if (*guardBack != GuardMagic)
+                {
+                    hive::LogError(comb::LogCombRoot,
+                                   "[MEM_DEBUG] [{}] Buffer OVERRUN detected! Address: {}, Size: {}, Tag: {}",
+                                   GetName(), ptr, info->size, info->GetTagOrDefault());
+                    hive::Assert(false, "Buffer overrun detected");
+                }
+            }
+        }
+
+        // 3. Fill with freed pattern (detect use-after-free)
+#if COMB_MEM_DEBUG_USE_AFTER_FREE
+        std::memset(ptr, FreedMemoryPattern, info->size);
+#endif
+
+        // 4. Record deallocation in history
+#if COMB_MEM_DEBUG_HISTORY
+        history_->RecordDeallocation(ptr, info->size);
+#endif
+
+        // 5. Unregister allocation
+        registry_->UnregisterAllocation(ptr);
+
+        // 6. Return to slab free-list
+        // In debug mode, the slab's free-list stores pointers in user data area (after guard)
+        // So we deallocate using ptr directly (which is userPtr)
+        for (auto& slab : slabs_)
+        {
+            // Check if this slab owns the memory block containing ptr
+            if (slab.Contains(ptr))
+            {
+                slab.Deallocate(ptr);
+                return;
+            }
+        }
+
+        // Should never happen - ptr should be from one of our slabs
+        hive::Assert(false, "Internal error: ptr not found in any slab");
+    }
+
+#endif // COMB_MEM_DEBUG
+}

--- a/Comb/include/comb/test_slab.cpp
+++ b/Comb/include/comb/test_slab.cpp
@@ -1,0 +1,322 @@
+#include <larvae/larvae.h>
+#include <comb/slab_allocator.h>
+#include <comb/allocator_concepts.h>
+
+namespace
+{
+    auto test1 = larvae::RegisterTest("SlabAllocator", "ConceptSatisfaction", []() {
+        using TestAllocator = comb::SlabAllocator<100, 32, 64, 128>;
+        larvae::AssertTrue((comb::Allocator<TestAllocator>));
+    });
+
+    auto test2 = larvae::RegisterTest("SlabAllocator", "Construction", []() {
+        comb::SlabAllocator<100, 32, 64, 128> slabs;
+
+        larvae::AssertEqual(slabs.GetSlabCount(), 3u);
+        larvae::AssertEqual(slabs.GetUsedMemory(), 0u);
+        larvae::AssertEqual(slabs.GetTotalMemory(), 100u * (32u + 64u + 128u));
+    });
+
+    auto test3 = larvae::RegisterTest("SlabAllocator", "BasicAllocation", []() {
+        comb::SlabAllocator<100, 32, 64, 128> slabs;
+
+        void* ptr = slabs.Allocate(32, 8);
+        larvae::AssertNotNull(ptr);
+        larvae::AssertEqual(slabs.GetUsedMemory(), 32u);
+
+        slabs.Deallocate(ptr);
+    });
+
+    auto test4 = larvae::RegisterTest("SlabAllocator", "SlabSelection", []() {
+        comb::SlabAllocator<100, 32, 64, 128> slabs;
+
+        void* ptr1 = slabs.Allocate(20, 8);
+        larvae::AssertNotNull(ptr1);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(0), 1u);
+
+        void* ptr2 = slabs.Allocate(50, 8);
+        larvae::AssertNotNull(ptr2);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(1), 1u);
+
+        void* ptr3 = slabs.Allocate(100, 8);
+        larvae::AssertNotNull(ptr3);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(2), 1u);
+
+        slabs.Deallocate(ptr1);
+        slabs.Deallocate(ptr2);
+        slabs.Deallocate(ptr3);
+    });
+
+    auto test5 = larvae::RegisterTest("SlabAllocator", "RoundUpToSizeClass", []() {
+        comb::SlabAllocator<100, 32, 64, 128> slabs;
+
+        void* ptr1 = slabs.Allocate(1, 8);
+        larvae::AssertNotNull(ptr1);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(0), 1u);
+
+        void* ptr2 = slabs.Allocate(33, 8);
+        larvae::AssertNotNull(ptr2);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(1), 1u);
+
+        slabs.Deallocate(ptr1);
+        slabs.Deallocate(ptr2);
+    });
+
+    auto test6 = larvae::RegisterTest("SlabAllocator", "MultipleAllocations", []() {
+        comb::SlabAllocator<10, 32, 64> slabs;
+
+        void* ptrs[20];
+
+        for (int i = 0; i < 10; ++i)
+        {
+            ptrs[i] = slabs.Allocate(32, 8);
+            larvae::AssertNotNull(ptrs[i]);
+        }
+
+        for (int i = 10; i < 20; ++i)
+        {
+            ptrs[i] = slabs.Allocate(64, 8);
+            larvae::AssertNotNull(ptrs[i]);
+        }
+
+        larvae::AssertEqual(slabs.GetSlabUsedCount(0), 10u);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(1), 10u);
+
+        for (int i = 0; i < 20; ++i)
+        {
+            slabs.Deallocate(ptrs[i]);
+        }
+
+        larvae::AssertEqual(slabs.GetSlabUsedCount(0), 0u);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(1), 0u);
+    });
+
+    auto test7 = larvae::RegisterTest("SlabAllocator", "SlabExhaustion", []() {
+        comb::SlabAllocator<5, 32> slabs;
+
+        void* ptrs[5];
+
+        for (int i = 0; i < 5; ++i)
+        {
+            ptrs[i] = slabs.Allocate(32, 8);
+            larvae::AssertNotNull(ptrs[i]);
+        }
+
+        void* overflow = slabs.Allocate(32, 8);
+        larvae::AssertNull(overflow);
+
+        slabs.Deallocate(ptrs[0]);
+
+        void* reused = slabs.Allocate(32, 8);
+        larvae::AssertNotNull(reused);
+        larvae::AssertEqual(reused, ptrs[0]);
+
+        for (int i = 0; i < 5; ++i)
+        {
+            slabs.Deallocate(ptrs[i]);
+        }
+    });
+
+    auto test8 = larvae::RegisterTest("SlabAllocator", "TooLargeAllocation", []() {
+        comb::SlabAllocator<100, 32, 64, 128> slabs;
+
+        void* ptr = slabs.Allocate(256, 8);
+        larvae::AssertNull(ptr);
+
+        larvae::AssertEqual(slabs.GetUsedMemory(), 0u);
+    });
+
+    auto test9 = larvae::RegisterTest("SlabAllocator", "Deallocation", []() {
+        comb::SlabAllocator<100, 32, 64> slabs;
+
+        void* ptr1 = slabs.Allocate(32, 8);
+        void* ptr2 = slabs.Allocate(64, 8);
+
+        larvae::AssertNotNull(ptr1);
+        larvae::AssertNotNull(ptr2);
+
+        slabs.Deallocate(ptr1);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(0), 0u);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(1), 1u);
+
+        slabs.Deallocate(ptr2);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(1), 0u);
+
+        larvae::AssertEqual(slabs.GetUsedMemory(), 0u);
+    });
+
+    auto test10 = larvae::RegisterTest("SlabAllocator", "DeallocateNullptr", []() {
+        comb::SlabAllocator<100, 32> slabs;
+
+        slabs.Deallocate(nullptr);
+
+        larvae::AssertEqual(slabs.GetUsedMemory(), 0u);
+    });
+
+    auto test11 = larvae::RegisterTest("SlabAllocator", "Reset", []() {
+        comb::SlabAllocator<100, 32, 64> slabs;
+
+        void* ptr1 = slabs.Allocate(32, 8);
+        void* ptr2 = slabs.Allocate(64, 8);
+        void* ptr3 = slabs.Allocate(32, 8);
+
+        larvae::AssertNotNull(ptr1);
+        larvae::AssertNotNull(ptr2);
+        larvae::AssertNotNull(ptr3);
+
+        larvae::AssertEqual(slabs.GetSlabUsedCount(0), 2u);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(1), 1u);
+
+        slabs.Reset();
+
+        larvae::AssertEqual(slabs.GetSlabUsedCount(0), 0u);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(1), 0u);
+        larvae::AssertEqual(slabs.GetUsedMemory(), 0u);
+
+        void* new_ptr = slabs.Allocate(32, 8);
+        larvae::AssertNotNull(new_ptr);
+
+        slabs.Deallocate(new_ptr);
+    });
+
+    auto test12 = larvae::RegisterTest("SlabAllocator", "MemoryRecycling", []() {
+        comb::SlabAllocator<100, 64> slabs;
+
+        void* ptr1 = slabs.Allocate(64, 8);
+        larvae::AssertNotNull(ptr1);
+
+        slabs.Deallocate(ptr1);
+
+        void* ptr2 = slabs.Allocate(64, 8);
+        larvae::AssertNotNull(ptr2);
+
+        larvae::AssertEqual(ptr1, ptr2);
+
+        slabs.Deallocate(ptr2);
+    });
+
+    auto test13 = larvae::RegisterTest("SlabAllocator", "GetName", []() {
+        comb::SlabAllocator<100, 32> slabs;
+
+        const char* name = slabs.GetName();
+        larvae::AssertNotNull(name);
+    });
+
+    auto test14 = larvae::RegisterTest("SlabAllocator", "GetSizeClasses", []() {
+        comb::SlabAllocator<100, 32, 64, 128> slabs;
+
+        auto sizes = slabs.GetSizeClasses();
+        larvae::AssertEqual(sizes[0], 32u);
+        larvae::AssertEqual(sizes[1], 64u);
+        larvae::AssertEqual(sizes[2], 128u);
+    });
+
+    auto test15 = larvae::RegisterTest("SlabAllocator", "GetSlabFreeCount", []() {
+        comb::SlabAllocator<10, 32> slabs;
+
+        larvae::AssertEqual(slabs.GetSlabFreeCount(0), 10u);
+
+        void* ptr = slabs.Allocate(32, 8);
+        larvae::AssertNotNull(ptr);
+
+        larvae::AssertEqual(slabs.GetSlabFreeCount(0), 9u);
+
+        slabs.Deallocate(ptr);
+
+        larvae::AssertEqual(slabs.GetSlabFreeCount(0), 10u);
+    });
+
+    auto test16 = larvae::RegisterTest("SlabAllocator", "MoveConstruction", []() {
+        comb::SlabAllocator<100, 32> slabs1;
+
+        void* ptr1 = slabs1.Allocate(32, 8);
+        larvae::AssertNotNull(ptr1);
+
+        comb::SlabAllocator<100, 32> slabs2{std::move(slabs1)};
+
+        larvae::AssertEqual(slabs2.GetSlabUsedCount(0), 1u);
+
+        // Debug tracking is transferred with move - can deallocate normally
+        slabs2.Deallocate(ptr1);
+
+        larvae::AssertEqual(slabs2.GetUsedMemory(), 0u);
+    });
+
+    auto test17 = larvae::RegisterTest("SlabAllocator", "MoveAssignment", []() {
+        comb::SlabAllocator<100, 32> slabs1;
+        comb::SlabAllocator<100, 32> slabs2;
+
+        void* ptr1 = slabs1.Allocate(32, 8);
+        larvae::AssertNotNull(ptr1);
+
+        slabs2 = std::move(slabs1);
+
+        larvae::AssertEqual(slabs2.GetSlabUsedCount(0), 1u);
+
+        // Debug tracking is transferred with move - can deallocate normally
+        slabs2.Deallocate(ptr1);
+
+        larvae::AssertEqual(slabs2.GetUsedMemory(), 0u);
+    });
+
+    auto test18 = larvae::RegisterTest("SlabAllocator", "PowerOfTwoSizeClasses", []() {
+        comb::SlabAllocator<100, 30, 60, 120> slabs;
+
+        auto sizes = slabs.GetSizeClasses();
+
+        larvae::AssertEqual(sizes[0], 32u);
+        larvae::AssertEqual(sizes[1], 64u);
+        larvae::AssertEqual(sizes[2], 128u);
+    });
+
+    auto test19 = larvae::RegisterTest("SlabAllocator", "NewDeleteHelpers", []() {
+        comb::SlabAllocator<100, 64> slabs;
+
+        struct TestStruct
+        {
+            int value;
+            float data;
+
+            TestStruct(int v, float d) : value{v}, data{d} {}
+        };
+
+        TestStruct* obj = comb::New<TestStruct>(slabs, 42, 3.14f);
+        larvae::AssertNotNull(obj);
+        larvae::AssertEqual(obj->value, 42);
+        larvae::AssertEqual(obj->data, 3.14f);
+
+        comb::Delete(slabs, obj);
+
+        larvae::AssertEqual(slabs.GetUsedMemory(), 0u);
+    });
+
+    auto test20 = larvae::RegisterTest("SlabAllocator", "MixedSizeAllocations", []() {
+        comb::SlabAllocator<100, 16, 32, 64, 128, 256> slabs;
+
+        void* ptr16 = slabs.Allocate(10, 8);
+        void* ptr32 = slabs.Allocate(20, 8);
+        void* ptr64 = slabs.Allocate(50, 8);
+        void* ptr128 = slabs.Allocate(100, 8);
+        void* ptr256 = slabs.Allocate(200, 8);
+
+        larvae::AssertNotNull(ptr16);
+        larvae::AssertNotNull(ptr32);
+        larvae::AssertNotNull(ptr64);
+        larvae::AssertNotNull(ptr128);
+        larvae::AssertNotNull(ptr256);
+
+        larvae::AssertEqual(slabs.GetSlabUsedCount(0), 1u);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(1), 1u);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(2), 1u);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(3), 1u);
+        larvae::AssertEqual(slabs.GetSlabUsedCount(4), 1u);
+
+        slabs.Deallocate(ptr16);
+        slabs.Deallocate(ptr32);
+        slabs.Deallocate(ptr64);
+        slabs.Deallocate(ptr128);
+        slabs.Deallocate(ptr256);
+
+        larvae::AssertEqual(slabs.GetUsedMemory(), 0u);
+    });
+}

--- a/Comb/tests/benchmark_pool.cpp
+++ b/Comb/tests/benchmark_pool.cpp
@@ -1,0 +1,125 @@
+#include <larvae/larvae.h>
+#include <comb/pool_allocator.h>
+#include <cstdlib>
+
+namespace
+{
+    struct SmallObject
+    {
+        int data[4]; // 16 bytes
+    };
+
+    struct MediumObject
+    {
+        int data[64]; // 256 bytes
+    };
+
+    auto bench1 = larvae::RegisterBenchmark("PoolAllocator", "SmallObjectAllocation", [](larvae::BenchmarkState& state) {
+        comb::PoolAllocator<SmallObject> pool{100000};
+
+        while (state.KeepRunning())
+        {
+            SmallObject* obj = comb::New<SmallObject>(pool);
+            larvae::DoNotOptimize(obj);
+
+            // Reset when pool full
+            if (pool.GetFreeCount() == 0)
+            {
+                pool.Reset();
+            }
+        }
+
+        state.SetBytesProcessed(state.iterations() * sizeof(SmallObject));
+        state.SetItemsProcessed(state.iterations());
+    });
+
+    auto bench2 = larvae::RegisterBenchmark("PoolAllocator", "MediumObjectAllocation", [](larvae::BenchmarkState& state) {
+        comb::PoolAllocator<MediumObject> pool{100000};
+
+        while (state.KeepRunning())
+        {
+            MediumObject* obj = comb::New<MediumObject>(pool);
+            larvae::DoNotOptimize(obj);
+
+            if (pool.GetFreeCount() == 0)
+            {
+                pool.Reset();
+            }
+        }
+
+        state.SetBytesProcessed(state.iterations() * sizeof(MediumObject));
+        state.SetItemsProcessed(state.iterations());
+    });
+
+    auto bench3 = larvae::RegisterBenchmark("PoolAllocator", "AllocationAndDeallocation", [](larvae::BenchmarkState& state) {
+        comb::PoolAllocator<SmallObject> pool{100000};
+
+        while (state.KeepRunning())
+        {
+            SmallObject* obj = comb::New<SmallObject>(pool);
+            larvae::DoNotOptimize(obj);
+            comb::Delete(pool, obj);
+        }
+
+        state.SetBytesProcessed(state.iterations() * sizeof(SmallObject));
+        state.SetItemsProcessed(state.iterations());
+    });
+
+    auto bench4 = larvae::RegisterBenchmark("PoolAllocator", "RapidRecycling", [](larvae::BenchmarkState& state) {
+        comb::PoolAllocator<SmallObject> pool{10};
+
+        while (state.KeepRunning())
+        {
+            // Allocate all
+            SmallObject* objects[10];
+            for (int i = 0; i < 10; ++i)
+            {
+                objects[i] = comb::New<SmallObject>(pool);
+                larvae::DoNotOptimize(objects[i]);
+            }
+
+            // Deallocate all
+            for (int i = 0; i < 10; ++i)
+            {
+                comb::Delete(pool, objects[i]);
+            }
+        }
+
+        state.SetItemsProcessed(state.iterations() * 20); // 10 allocs + 10 deallocs
+    });
+
+    auto bench5 = larvae::RegisterBenchmark("PoolAllocator", "ResetPerformance", [](larvae::BenchmarkState& state) {
+        comb::PoolAllocator<SmallObject> pool{10000};
+
+        // Fill pool
+        for (size_t i = 0; i < 10000; ++i)
+        {
+            (void)comb::New<SmallObject>(pool);
+        }
+
+        while (state.KeepRunning())
+        {
+            pool.Reset();
+
+            // Refill for next iteration
+            for (size_t i = 0; i < 10000; ++i)
+            {
+                (void)comb::New<SmallObject>(pool);
+            }
+        }
+
+        state.SetItemsProcessed(state.iterations());
+    });
+
+    auto bench6 = larvae::RegisterBenchmark("malloc", "SmallObjectAllocation", [](larvae::BenchmarkState& state) {
+        while (state.KeepRunning())
+        {
+            void* ptr = std::malloc(sizeof(SmallObject));
+            larvae::DoNotOptimize(ptr);
+            std::free(ptr);
+        }
+
+        state.SetBytesProcessed(state.iterations() * sizeof(SmallObject));
+        state.SetItemsProcessed(state.iterations());
+    });
+}

--- a/Comb/tests/test_pool.cpp
+++ b/Comb/tests/test_pool.cpp
@@ -1,0 +1,287 @@
+#include <larvae/larvae.h>
+#include <comb/pool_allocator.h>
+#include <cstring>
+
+namespace
+{
+    struct TestObject
+    {
+        int value;
+        float data;
+
+        TestObject(int v = 0, float d = 0.0f) : value{v}, data{d} {}
+    };
+
+    struct LargeObject
+    {
+        char buffer[256];
+    };
+
+    auto test1 = larvae::RegisterTest("PoolAllocator", "ConstructorInitializesCorrectly", []() {
+        comb::PoolAllocator<TestObject> pool{100};
+
+        larvae::AssertEqual(pool.GetCapacity(), 100u);
+        larvae::AssertEqual(pool.GetUsedCount(), 0u);
+        larvae::AssertEqual(pool.GetFreeCount(), 100u);
+        larvae::AssertTrue(pool.GetTotalMemory() > 0);
+    });
+
+    auto test2 = larvae::RegisterTest("PoolAllocator", "AllocateReturnsValidPointer", []() {
+        comb::PoolAllocator<TestObject> pool{10};
+
+        void* ptr = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+        larvae::AssertNotNull(ptr);
+        larvae::AssertEqual(pool.GetUsedCount(), 1u);
+        larvae::AssertEqual(pool.GetFreeCount(), 9u);
+
+        pool.Deallocate(ptr);
+    });
+
+    auto test3 = larvae::RegisterTest("PoolAllocator", "AllocateMultipleObjects", []() {
+        comb::PoolAllocator<TestObject> pool{10};
+
+        void* ptrs[5];
+        for (int i = 0; i < 5; ++i)
+        {
+            ptrs[i] = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+            larvae::AssertNotNull(ptrs[i]);
+        }
+
+        larvae::AssertEqual(pool.GetUsedCount(), 5u);
+        larvae::AssertEqual(pool.GetFreeCount(), 5u);
+
+        // All pointers should be different
+        for (int i = 0; i < 4; ++i)
+        {
+            larvae::AssertNotEqual(ptrs[i], ptrs[i + 1]);
+        }
+
+        // Clean up
+        for (int i = 0; i < 5; ++i)
+        {
+            pool.Deallocate(ptrs[i]);
+        }
+    });
+
+    auto test4 = larvae::RegisterTest("PoolAllocator", "AllocateWhenPoolExhaustedReturnsNull", []() {
+        comb::PoolAllocator<TestObject> pool{2};
+
+        void* ptr1 = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+        void* ptr2 = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+        void* ptr3 = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+
+        larvae::AssertNotNull(ptr1);
+        larvae::AssertNotNull(ptr2);
+        larvae::AssertTrue(ptr3 == nullptr);
+        larvae::AssertEqual(pool.GetUsedCount(), 2u);
+        larvae::AssertEqual(pool.GetFreeCount(), 0u);
+
+        // Clean up
+        pool.Deallocate(ptr1);
+        pool.Deallocate(ptr2);
+    });
+
+    auto test5 = larvae::RegisterTest("PoolAllocator", "DeallocateWithNullptrIsSafe", []() {
+        comb::PoolAllocator<TestObject> pool{10};
+
+        pool.Deallocate(nullptr);
+        larvae::AssertEqual(pool.GetUsedCount(), 0u);
+    });
+
+    auto test6 = larvae::RegisterTest("PoolAllocator", "DeallocateReturnsToFreeList", []() {
+        comb::PoolAllocator<TestObject> pool{10};
+
+        void* ptr = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+        larvae::AssertEqual(pool.GetUsedCount(), 1u);
+
+        pool.Deallocate(ptr);
+        larvae::AssertEqual(pool.GetUsedCount(), 0u);
+        larvae::AssertEqual(pool.GetFreeCount(), 10u);
+    });
+
+    auto test7 = larvae::RegisterTest("PoolAllocator", "DeallocatedMemoryCanBeReused", []() {
+        comb::PoolAllocator<TestObject> pool{10};
+
+        void* ptr1 = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+        pool.Deallocate(ptr1);
+
+        void* ptr2 = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+
+        larvae::AssertEqual(ptr1, ptr2);
+
+        pool.Deallocate(ptr2);
+    });
+
+    auto test8 = larvae::RegisterTest("PoolAllocator", "AllocateAndDeallocateCycle", []() {
+        comb::PoolAllocator<TestObject> pool{5};
+
+        void* ptrs[5];
+        for (int i = 0; i < 5; ++i)
+        {
+            ptrs[i] = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+        }
+        larvae::AssertEqual(pool.GetUsedCount(), 5u);
+
+        for (int i = 0; i < 5; ++i)
+        {
+            pool.Deallocate(ptrs[i]);
+        }
+        larvae::AssertEqual(pool.GetUsedCount(), 0u);
+
+        for (int i = 0; i < 5; ++i)
+        {
+            ptrs[i] = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+            larvae::AssertNotNull(ptrs[i]);
+        }
+        larvae::AssertEqual(pool.GetUsedCount(), 5u);
+
+        // Clean up second batch
+        for (int i = 0; i < 5; ++i)
+        {
+            pool.Deallocate(ptrs[i]);
+        }
+    });
+
+    auto test9 = larvae::RegisterTest("PoolAllocator", "ResetClearsAllAllocations", []() {
+        comb::PoolAllocator<TestObject> pool{10};
+
+        for (int i = 0; i < 5; ++i)
+        {
+            static_cast<void>(pool.Allocate(sizeof(TestObject), alignof(TestObject)));
+        }
+        larvae::AssertEqual(pool.GetUsedCount(), 5u);
+
+        pool.Reset();
+
+        larvae::AssertEqual(pool.GetUsedCount(), 0u);
+        larvae::AssertEqual(pool.GetFreeCount(), 10u);
+    });
+
+    auto test10 = larvae::RegisterTest("PoolAllocator", "AllocatedMemoryIsWritable", []() {
+        comb::PoolAllocator<TestObject> pool{10};
+
+        void* ptr = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+        std::memset(ptr, 0xAA, sizeof(TestObject));
+
+        auto* bytes = static_cast<unsigned char*>(ptr);
+        for (size_t i = 0; i < sizeof(TestObject); ++i)
+        {
+            larvae::AssertEqual(bytes[i], static_cast<unsigned char>(0xAA));
+        }
+
+        pool.Deallocate(ptr);
+    });
+
+    auto test11 = larvae::RegisterTest("PoolAllocator", "AllocateAndConstructObject", []() {
+        comb::PoolAllocator<TestObject> pool{10};
+
+        void* mem = pool.Allocate(sizeof(TestObject), alignof(TestObject));
+        auto* obj = new (mem) TestObject(42, 3.14f);
+
+        larvae::AssertNotNull(obj);
+        larvae::AssertEqual(obj->value, 42);
+        larvae::AssertEqual(obj->data, 3.14f);
+
+        obj->~TestObject();
+        pool.Deallocate(mem);
+    });
+
+    auto test12 = larvae::RegisterTest("PoolAllocator", "UseCombNewAndDelete", []() {
+        comb::PoolAllocator<TestObject> pool{10};
+
+        TestObject* obj = comb::New<TestObject>(pool, 99, 2.71f);
+
+        larvae::AssertNotNull(obj);
+        larvae::AssertEqual(obj->value, 99);
+        larvae::AssertEqual(obj->data, 2.71f);
+        larvae::AssertEqual(pool.GetUsedCount(), 1u);
+
+        comb::Delete(pool, obj);
+        larvae::AssertEqual(pool.GetUsedCount(), 0u);
+    });
+
+    auto test13 = larvae::RegisterTest("PoolAllocator", "GetNameReturnsCorrectName", []() {
+        comb::PoolAllocator<TestObject> pool{10};
+
+        larvae::AssertStringEqual(pool.GetName(), "PoolAllocator");
+    });
+
+    auto test14 = larvae::RegisterTest("PoolAllocator", "GetTotalMemoryReturnsCorrectValue", []() {
+        constexpr size_t N = 100;
+        comb::PoolAllocator<TestObject> pool{N};
+
+        larvae::AssertEqual(pool.GetTotalMemory(), N * sizeof(TestObject));
+    });
+
+    auto test15 = larvae::RegisterTest("PoolAllocator", "LargeObjectsWork", []() {
+        comb::PoolAllocator<LargeObject> pool{10};
+
+        LargeObject* obj = comb::New<LargeObject>(pool);
+        larvae::AssertNotNull(obj);
+
+        std::memset(obj->buffer, 0xFF, 256);
+        larvae::AssertEqual(obj->buffer[0], static_cast<char>(0xFF));
+        larvae::AssertEqual(obj->buffer[255], static_cast<char>(0xFF));
+
+        comb::Delete(pool, obj);
+    });
+
+    auto test16 = larvae::RegisterTest("PoolAllocator", "ManyAllocationsAndDeallocations", []() {
+        comb::PoolAllocator<TestObject> pool{100};
+
+        for (int cycle = 0; cycle < 10; ++cycle)
+        {
+            TestObject* objects[50];
+            for (int i = 0; i < 50; ++i)
+            {
+                objects[i] = comb::New<TestObject>(pool, i, static_cast<float>(i) * 1.5f);
+                larvae::AssertNotNull(objects[i]);
+            }
+
+            larvae::AssertEqual(pool.GetUsedCount(), 50u);
+
+            for (int i = 0; i < 50; ++i)
+            {
+                comb::Delete(pool, objects[i]);
+            }
+
+            larvae::AssertEqual(pool.GetUsedCount(), 0u);
+        }
+    });
+
+    auto test17 = larvae::RegisterTest("PoolAllocator", "PartialDeallocation", []() {
+        comb::PoolAllocator<TestObject> pool{10};
+
+        TestObject* objects[10];
+        for (int i = 0; i < 10; ++i)
+        {
+            objects[i] = comb::New<TestObject>(pool, i, 0.0f);
+        }
+
+        // Deallocate some objects
+        comb::Delete(pool, objects[2]);
+        comb::Delete(pool, objects[5]);
+        comb::Delete(pool, objects[8]);
+
+        larvae::AssertEqual(pool.GetUsedCount(), 7u);
+        larvae::AssertEqual(pool.GetFreeCount(), 3u);
+
+        TestObject* new1 = comb::New<TestObject>(pool, 100, 0.0f);
+        TestObject* new2 = comb::New<TestObject>(pool, 200, 0.0f);
+
+        larvae::AssertNotNull(new1);
+        larvae::AssertNotNull(new2);
+        larvae::AssertEqual(pool.GetUsedCount(), 9u);
+
+        // Clean up remaining objects
+        for (int i = 0; i < 10; ++i)
+        {
+            if (i != 2 && i != 5 && i != 8) // Skip already deallocated
+            {
+                comb::Delete(pool, objects[i]);
+            }
+        }
+        comb::Delete(pool, new1);
+        comb::Delete(pool, new2);
+    });
+}


### PR DESCRIPTION
Introduces comb::PoolAllocator, a fixed-size, free-list based memory pool for fast allocation/deallocation of objects. Includes comprehensive unit tests and benchmarks to validate allocator correctness and performance for various object sizes and usage patterns.