### PR TITLE
Fix bugs and add tests across Queen, Comb, and Wax

### DIFF
--- a/Comb/include/comb/allocator_concepts.h
+++ b/Comb/include/comb/allocator_concepts.h
@@ -2,8 +2,6 @@
 
 #include <concepts>
 #include <cstddef>
-#include <type_traits>
-#include <hive/core/assert.h>
 
 namespace comb
 {
@@ -26,55 +24,4 @@ namespace comb
         { allocator.GetTotalMemory() } -> std::convertible_to<size_t>;
         { allocator.GetName() } -> std::convertible_to<const char*>;
     };
-
-    /**
-     * Allocate and construct an object using an allocator
-     *
-     * Returns nullptr if allocation fails (graceful failure in release).
-     * Asserts in debug if allocation fails.
-     *
-     * @tparam T Type to construct
-     * @tparam Alloc Allocator type (must satisfy Allocator concept)
-     * @tparam Args Constructor argument types
-     * @param allocator The allocator to use
-     * @param args Constructor arguments
-     * @return Pointer to constructed object, or nullptr on failure
-     *
-     */
-    template<typename T, Allocator Alloc, typename... Args>
-    [[nodiscard]] T* New(Alloc& allocator, Args&&... args)
-    {
-        void* mem = allocator.Allocate(sizeof(T), alignof(T));
-        hive::Assert(mem != nullptr, "Allocation failed in New<T>()");
-        if (!mem) return nullptr;
-        return new (mem) T{std::forward<Args>(args)...};
-    }
-
-    /**
-     * Destroy and deallocate an object using an allocator
-     *
-     * IMPORTANT: For maximum performance, ptr MUST NOT be nullptr.
-     * Caller is responsible for null-checking before calling Delete().
-     *
-     * In debug builds, asserts if ptr is nullptr.
-     * In release builds, undefined behavior if ptr is nullptr (zero overhead).
-     *
-     * @tparam T Type to destroy
-     * @tparam Alloc Allocator type (must satisfy Allocator concept)
-     * @param allocator The allocator to use
-     * @param ptr Pointer to object (MUST NOT be nullptr)
-     *
-     */
-    template<typename T, Allocator Alloc>
-    void Delete(Alloc& allocator, T* ptr)
-    {
-        hive::Assert(ptr != nullptr, "Delete() called with nullptr - check before calling");
-
-        if constexpr (!std::is_trivially_destructible_v<T>)
-        {
-            ptr->~T();
-        }
-
-        allocator.Deallocate(ptr);
-    }
 }

--- a/Comb/include/comb/buddy_allocator.h
+++ b/Comb/include/comb/buddy_allocator.h
@@ -348,6 +348,34 @@ namespace comb
             return "BuddyAllocator";
         }
 
+        /**
+         * Reset allocator to initial state
+         *
+         * All existing allocations become invalid.
+         * Rebuilds the free list as a single top-level block.
+         */
+        void Reset()
+        {
+            for (size_t i = 0; i < MaxLevels; ++i)
+            {
+                free_lists_[i] = nullptr;
+            }
+
+            size_t topLevel = GetLevel(capacity_);
+            auto* block = static_cast<FreeBlock*>(memory_block_);
+            block->next = nullptr;
+            free_lists_[topLevel] = block;
+
+            used_memory_ = 0;
+
+#if COMB_MEM_DEBUG
+            if (registry_)
+            {
+                registry_->Clear();
+            }
+#endif
+        }
+
     private:
         // Convert size to level (0 = 64B, 1 = 128B, 2 = 256B, etc.)
         constexpr size_t GetLevel(size_t size) const

--- a/Comb/include/comb/debug/global_memory_tracker.h
+++ b/Comb/include/comb/debug/global_memory_tracker.h
@@ -186,11 +186,8 @@ public:
             globalStats.totalBytesAllocated += allocStats.totalBytesAllocated;
             globalStats.overheadBytes += allocStats.overheadBytes;
 
-            // Peak is max across all allocators
-            if (allocStats.peakBytesUsed > globalStats.peakBytesUsed)
-            {
-                globalStats.peakBytesUsed = allocStats.peakBytesUsed;
-            }
+            // Sum peaks across allocators (upper bound — individual peaks may not coincide)
+            globalStats.peakBytesUsed += allocStats.peakBytesUsed;
         }
 
         return globalStats;

--- a/Comb/include/comb/debug/platform_utils.h
+++ b/Comb/include/comb/debug/platform_utils.h
@@ -22,6 +22,7 @@
 
 #include <hive/core/assert.h>
 #include <cstdint>
+#include <cstdio>
 
 // Platform includes (use Hive's platform detection macros)
 #if HIVE_PLATFORM_WINDOWS

--- a/Comb/include/comb/thread_safe_allocator.h
+++ b/Comb/include/comb/thread_safe_allocator.h
@@ -103,7 +103,8 @@ namespace comb
          * Get the underlying allocator (not thread-safe access!)
          *
          * Warning: Direct access to underlying allocator bypasses thread safety.
-         * Only use for operations that don't require thread safety (e.g., GetUsedMemory).
+         * Prefer using the wrapper's methods (GetUsedMemory, GetTotalMemory) which are mutex-protected.
+         * Only use Underlying() for allocator-specific methods not exposed by the wrapper.
          */
         [[nodiscard]] UnderlyingAllocator& Underlying() noexcept
         {

--- a/Comb/tests/benchmark_pool.cpp
+++ b/Comb/tests/benchmark_pool.cpp
@@ -1,5 +1,6 @@
 #include <larvae/larvae.h>
 #include <comb/pool_allocator.h>
+#include <comb/new.h>
 #include <cstdlib>
 
 namespace

--- a/Comb/tests/test_default_allocator.cpp
+++ b/Comb/tests/test_default_allocator.cpp
@@ -1,0 +1,194 @@
+#include <larvae/larvae.h>
+#include <comb/default_allocator.h>
+#include <comb/new.h>
+
+namespace
+{
+    constexpr size_t operator""_KB(unsigned long long kb) { return kb * 1024; }
+    constexpr size_t operator""_MB(unsigned long long mb) { return mb * 1024 * 1024; }
+
+    // =============================================================================
+    // DefaultAllocator Concept
+    // =============================================================================
+
+    auto test1 = larvae::RegisterTest("DefaultAllocator", "ConceptSatisfaction", []() {
+        larvae::AssertTrue((comb::Allocator<comb::DefaultAllocator>));
+    });
+
+    // =============================================================================
+    // DefaultAllocator Basic Usage
+    // =============================================================================
+
+    auto test2 = larvae::RegisterTest("DefaultAllocator", "BasicAllocation", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        comb::DefaultAllocator alloc{buddy};
+
+        void* ptr = alloc.Allocate(64, 8);
+        larvae::AssertNotNull(ptr);
+        larvae::AssertTrue(alloc.GetUsedMemory() > 0);
+
+        alloc.Deallocate(ptr);
+        larvae::AssertEqual(alloc.GetUsedMemory(), 0u);
+    });
+
+    auto test3 = larvae::RegisterTest("DefaultAllocator", "NewDeleteWorks", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        comb::DefaultAllocator alloc{buddy};
+
+        struct TestObj
+        {
+            int x;
+            float y;
+            TestObj(int a, float b) : x{a}, y{b} {}
+        };
+
+        TestObj* obj = comb::New<TestObj>(alloc, 42, 3.14f);
+        larvae::AssertNotNull(obj);
+        larvae::AssertEqual(obj->x, 42);
+        larvae::AssertEqual(obj->y, 3.14f);
+
+        comb::Delete(alloc, obj);
+        larvae::AssertEqual(alloc.GetUsedMemory(), 0u);
+    });
+
+    // =============================================================================
+    // GetDefaultAllocator (Singleton)
+    // =============================================================================
+
+    auto test4 = larvae::RegisterTest("DefaultAllocator", "GetDefaultAllocatorReturnsSameInstance", []() {
+        comb::DefaultAllocator& alloc1 = comb::GetDefaultAllocator();
+        comb::DefaultAllocator& alloc2 = comb::GetDefaultAllocator();
+
+        larvae::AssertEqual(&alloc1, &alloc2);
+    });
+
+    auto test5 = larvae::RegisterTest("DefaultAllocator", "GetDefaultAllocatorIsUsable", []() {
+        comb::DefaultAllocator& alloc = comb::GetDefaultAllocator();
+
+        void* ptr = alloc.Allocate(128, 8);
+        larvae::AssertNotNull(ptr);
+        larvae::AssertTrue(alloc.GetUsedMemory() > 0);
+
+        alloc.Deallocate(ptr);
+    });
+
+    auto test6 = larvae::RegisterTest("DefaultAllocator", "GetDefaultAllocatorHas32MB", []() {
+        comb::DefaultAllocator& alloc = comb::GetDefaultAllocator();
+
+        larvae::AssertEqual(alloc.GetTotalMemory(), 32_MB);
+    });
+
+    // =============================================================================
+    // ModuleAllocator
+    // =============================================================================
+
+    auto test7 = larvae::RegisterTest("ModuleAllocator", "ConstructionAndBasicUsage", []() {
+        comb::ModuleAllocator module{"TestModule", 1_MB};
+
+        larvae::AssertStringEqual(module.GetName(), "TestModule");
+        larvae::AssertEqual(module.GetTotalMemory(), 1_MB);
+        larvae::AssertEqual(module.GetUsedMemory(), 0u);
+    });
+
+    auto test8 = larvae::RegisterTest("ModuleAllocator", "GetReturnsDefaultAllocator", []() {
+        comb::ModuleAllocator module{"TestModule", 1_MB};
+
+        comb::DefaultAllocator& alloc = module.Get();
+
+        void* ptr = alloc.Allocate(64, 8);
+        larvae::AssertNotNull(ptr);
+        larvae::AssertTrue(module.GetUsedMemory() > 0);
+
+        alloc.Deallocate(ptr);
+        larvae::AssertEqual(module.GetUsedMemory(), 0u);
+    });
+
+    auto test9 = larvae::RegisterTest("ModuleAllocator", "GetUnderlyingReturnsBuddyAllocator", []() {
+        comb::ModuleAllocator module{"TestModule", 1_MB};
+
+        comb::BuddyAllocator& buddy = module.GetUnderlying();
+
+        larvae::AssertEqual(buddy.GetTotalMemory(), 1_MB);
+        larvae::AssertStringEqual(buddy.GetName(), "BuddyAllocator");
+    });
+
+    auto test10 = larvae::RegisterTest("ModuleAllocator", "ConstGetReturnsConstRef", []() {
+        const comb::ModuleAllocator module{"TestModule", 1_MB};
+
+        const comb::DefaultAllocator& alloc = module.Get();
+        larvae::AssertEqual(alloc.GetTotalMemory(), 1_MB);
+    });
+
+    // =============================================================================
+    // ModuleRegistry
+    // =============================================================================
+
+    auto test11 = larvae::RegisterTest("ModuleRegistry", "ModuleRegistersOnConstruction", []() {
+        size_t countBefore = comb::ModuleRegistry::GetInstance().GetCount();
+
+        {
+            comb::ModuleAllocator module{"RegTestModule", 1_MB};
+            size_t countDuring = comb::ModuleRegistry::GetInstance().GetCount();
+            larvae::AssertEqual(countDuring, countBefore + 1);
+        }
+
+        size_t countAfter = comb::ModuleRegistry::GetInstance().GetCount();
+        larvae::AssertEqual(countAfter, countBefore);
+    });
+
+    auto test12 = larvae::RegisterTest("ModuleRegistry", "ModuleUnregistersOnDestruction", []() {
+        size_t countBefore = comb::ModuleRegistry::GetInstance().GetCount();
+
+        {
+            comb::ModuleAllocator module1{"RegTest1", 512_KB};
+            comb::ModuleAllocator module2{"RegTest2", 512_KB};
+
+            larvae::AssertEqual(comb::ModuleRegistry::GetInstance().GetCount(), countBefore + 2);
+        }
+
+        larvae::AssertEqual(comb::ModuleRegistry::GetInstance().GetCount(), countBefore);
+    });
+
+    auto test13 = larvae::RegisterTest("ModuleRegistry", "GetInstanceReturnsSameInstance", []() {
+        comb::ModuleRegistry& reg1 = comb::ModuleRegistry::GetInstance();
+        comb::ModuleRegistry& reg2 = comb::ModuleRegistry::GetInstance();
+
+        larvae::AssertEqual(&reg1, &reg2);
+    });
+
+    auto test14 = larvae::RegisterTest("ModuleRegistry", "MultipleModulesTrackIndependently", []() {
+        comb::ModuleAllocator module1{"ModA", 1_MB};
+        comb::ModuleAllocator module2{"ModB", 2_MB};
+
+        comb::DefaultAllocator& allocA = module1.Get();
+        comb::DefaultAllocator& allocB = module2.Get();
+
+        void* ptrA = allocA.Allocate(256, 8);
+        void* ptrB = allocB.Allocate(512, 8);
+
+        larvae::AssertNotNull(ptrA);
+        larvae::AssertNotNull(ptrB);
+
+        // Each module tracks independently
+        larvae::AssertTrue(module1.GetUsedMemory() > 0);
+        larvae::AssertTrue(module2.GetUsedMemory() > 0);
+
+        // Different capacities
+        larvae::AssertEqual(module1.GetTotalMemory(), 1_MB);
+        larvae::AssertEqual(module2.GetTotalMemory(), 2_MB);
+
+        allocA.Deallocate(ptrA);
+        allocB.Deallocate(ptrB);
+    });
+
+    auto test15 = larvae::RegisterTest("ModuleRegistry", "GetEntryReturnsCorrectInfo", []() {
+        comb::ModuleAllocator module{"EntryTestModule", 1_MB};
+
+        // The new module should be the last entry
+        size_t idx = comb::ModuleRegistry::GetInstance().GetCount() - 1;
+        const auto& entry = comb::ModuleRegistry::GetInstance().GetEntry(idx);
+
+        larvae::AssertStringEqual(entry.name, "EntryTestModule");
+        larvae::AssertEqual(entry.allocator, &module);
+    });
+}

--- a/Comb/tests/test_linear.cpp
+++ b/Comb/tests/test_linear.cpp
@@ -1,5 +1,6 @@
 #include <larvae/larvae.h>
 #include <comb/linear_allocator.h>
+#include <comb/new.h>
 #include <cstring>
 
 namespace {

--- a/Comb/tests/test_pool.cpp
+++ b/Comb/tests/test_pool.cpp
@@ -1,5 +1,6 @@
 #include <larvae/larvae.h>
 #include <comb/pool_allocator.h>
+#include <comb/new.h>
 #include <cstring>
 
 namespace

--- a/Comb/tests/test_slab.cpp
+++ b/Comb/tests/test_slab.cpp
@@ -1,6 +1,7 @@
 #include <larvae/larvae.h>
 #include <comb/slab_allocator.h>
 #include <comb/allocator_concepts.h>
+#include <comb/new.h>
 
 namespace
 {

--- a/Comb/tests/test_stack.cpp
+++ b/Comb/tests/test_stack.cpp
@@ -1,0 +1,477 @@
+#include <larvae/larvae.h>
+#include <comb/stack_allocator.h>
+#include <comb/new.h>
+#include <cstring>
+
+namespace
+{
+    constexpr size_t operator""_KB(unsigned long long kb) { return kb * 1024; }
+    constexpr size_t operator""_MB(unsigned long long mb) { return mb * 1024 * 1024; }
+
+    // =============================================================================
+    // Concept Satisfaction
+    // =============================================================================
+
+    auto test1 = larvae::RegisterTest("StackAllocator", "ConceptSatisfaction", []() {
+        larvae::AssertTrue((comb::Allocator<comb::StackAllocator>));
+    });
+
+    // =============================================================================
+    // Basic Functionality
+    // =============================================================================
+
+    auto test2 = larvae::RegisterTest("StackAllocator", "ConstructorInitializesCorrectly", []() {
+        comb::StackAllocator allocator{1024};
+
+        larvae::AssertEqual(allocator.GetUsedMemory(), 0u);
+        larvae::AssertEqual(allocator.GetTotalMemory(), 1024u);
+        larvae::AssertStringEqual(allocator.GetName(), "StackAllocator");
+    });
+
+    auto test3 = larvae::RegisterTest("StackAllocator", "AllocateReturnsValidPointer", []() {
+        comb::StackAllocator allocator{1024};
+
+        void* ptr = allocator.Allocate(64, 8);
+
+        larvae::AssertNotNull(ptr);
+        larvae::AssertEqual(allocator.GetUsedMemory(), 64u);
+    });
+
+    auto test4 = larvae::RegisterTest("StackAllocator", "AllocateUpdatesUsedMemory", []() {
+        comb::StackAllocator allocator{1024};
+
+        larvae::AssertEqual(allocator.GetUsedMemory(), 0u);
+
+        static_cast<void>(allocator.Allocate(104, 8));
+        larvae::AssertEqual(allocator.GetUsedMemory(), 104u);
+
+        static_cast<void>(allocator.Allocate(200, 8));
+        larvae::AssertEqual(allocator.GetUsedMemory(), 304u);
+    });
+
+    auto test5 = larvae::RegisterTest("StackAllocator", "MultipleAllocationsAreSequential", []() {
+        comb::StackAllocator allocator{1024};
+
+        void* ptr1 = allocator.Allocate(64, 8);
+        void* ptr2 = allocator.Allocate(64, 8);
+        void* ptr3 = allocator.Allocate(64, 8);
+
+        larvae::AssertNotNull(ptr1);
+        larvae::AssertNotNull(ptr2);
+        larvae::AssertNotNull(ptr3);
+
+        // Pointers should be in increasing order
+        larvae::AssertTrue(ptr2 > ptr1);
+        larvae::AssertTrue(ptr3 > ptr2);
+
+        larvae::AssertEqual(allocator.GetUsedMemory(), 192u);
+    });
+
+    // =============================================================================
+    // Alignment
+    // =============================================================================
+
+    auto test6 = larvae::RegisterTest("StackAllocator", "AllocateRespectsAlignment", []() {
+        comb::StackAllocator allocator{1024};
+
+        void* ptr16 = allocator.Allocate(10, 16);
+        larvae::AssertEqual(reinterpret_cast<uintptr_t>(ptr16) % 16, 0u);
+
+        void* ptr32 = allocator.Allocate(10, 32);
+        larvae::AssertEqual(reinterpret_cast<uintptr_t>(ptr32) % 32, 0u);
+
+        void* ptr64 = allocator.Allocate(10, 64);
+        larvae::AssertEqual(reinterpret_cast<uintptr_t>(ptr64) % 64, 0u);
+    });
+
+    auto test7 = larvae::RegisterTest("StackAllocator", "AllocateWithMisalignedStart", []() {
+        comb::StackAllocator allocator{1024};
+
+        // Allocate 1 byte to misalign current pointer
+        static_cast<void>(allocator.Allocate(1, 1));
+
+        // Next allocation should still be properly aligned
+        void* ptr = allocator.Allocate(64, 16);
+        larvae::AssertEqual(reinterpret_cast<uintptr_t>(ptr) % 16, 0u);
+
+        // Used memory includes padding
+        larvae::AssertGreaterThan(allocator.GetUsedMemory(), 65u);
+    });
+
+    auto test8 = larvae::RegisterTest("StackAllocator", "Alignment128", []() {
+        comb::StackAllocator allocator{4_KB};
+
+        // Misalign first
+        static_cast<void>(allocator.Allocate(3, 1));
+
+        void* ptr = allocator.Allocate(64, 128);
+        larvae::AssertNotNull(ptr);
+        larvae::AssertEqual(reinterpret_cast<uintptr_t>(ptr) % 128, 0u);
+    });
+
+    // =============================================================================
+    // Out of Memory
+    // =============================================================================
+
+    auto test9 = larvae::RegisterTest("StackAllocator", "AllocateReturnsNullWhenOutOfMemory", []() {
+        comb::StackAllocator allocator{80};
+
+        void* ptr1 = allocator.Allocate(64, 8);
+        larvae::AssertNotNull(ptr1);
+
+        // Second allocation should fail (not enough space)
+        void* ptr2 = allocator.Allocate(64, 8);
+        larvae::AssertNull(ptr2);
+    });
+
+    auto test10 = larvae::RegisterTest("StackAllocator", "AllocateSizeLargerThanCapacity", []() {
+        comb::StackAllocator allocator{1024};
+
+        void* ptr = allocator.Allocate(2048, 8);
+
+        larvae::AssertNull(ptr);
+        larvae::AssertEqual(allocator.GetUsedMemory(), 0u);
+    });
+
+    // =============================================================================
+    // Markers
+    // =============================================================================
+
+    auto test11 = larvae::RegisterTest("StackAllocator", "GetMarkerReturnsCurrentPosition", []() {
+        comb::StackAllocator allocator{1024};
+
+        auto marker0 = allocator.GetMarker();
+        larvae::AssertEqual(marker0, 0u);
+
+        static_cast<void>(allocator.Allocate(100, 8));
+        auto marker1 = allocator.GetMarker();
+
+        static_cast<void>(allocator.Allocate(200, 8));
+        auto marker2 = allocator.GetMarker();
+
+        // Markers should be increasing
+        larvae::AssertTrue(marker1 > marker0);
+        larvae::AssertTrue(marker2 > marker1);
+    });
+
+    auto test12 = larvae::RegisterTest("StackAllocator", "FreeToMarkerRestoresPosition", []() {
+        comb::StackAllocator allocator{1024};
+
+        static_cast<void>(allocator.Allocate(104, 8));
+        auto marker = allocator.GetMarker();
+
+        static_cast<void>(allocator.Allocate(200, 8));
+        larvae::AssertEqual(allocator.GetUsedMemory(), 304u);
+
+        allocator.FreeToMarker(marker);
+
+        larvae::AssertEqual(allocator.GetUsedMemory(), 104u);
+
+        // Should be able to allocate again from marker position
+        void* ptr = allocator.Allocate(56, 8);
+        larvae::AssertNotNull(ptr);
+    });
+
+    auto test13 = larvae::RegisterTest("StackAllocator", "NestedMarkers", []() {
+        comb::StackAllocator allocator{1024};
+
+        static_cast<void>(allocator.Allocate(104, 8));
+        auto marker1 = allocator.GetMarker();
+
+        static_cast<void>(allocator.Allocate(200, 8));
+        auto marker2 = allocator.GetMarker();
+
+        static_cast<void>(allocator.Allocate(304, 8));
+        larvae::AssertEqual(allocator.GetUsedMemory(), 608u);
+
+        // Free inner scope
+        allocator.FreeToMarker(marker2);
+        larvae::AssertEqual(allocator.GetUsedMemory(), 304u);
+
+        // Free outer scope
+        allocator.FreeToMarker(marker1);
+        larvae::AssertEqual(allocator.GetUsedMemory(), 104u);
+    });
+
+    auto test14 = larvae::RegisterTest("StackAllocator", "FreeToMarkerZeroFreesAll", []() {
+        comb::StackAllocator allocator{1024};
+
+        static_cast<void>(allocator.Allocate(200, 8));
+        static_cast<void>(allocator.Allocate(300, 8));
+
+        allocator.FreeToMarker(0);
+
+        larvae::AssertEqual(allocator.GetUsedMemory(), 0u);
+
+        // Can allocate again from start
+        void* ptr = allocator.Allocate(64, 8);
+        larvae::AssertNotNull(ptr);
+    });
+
+    auto test15 = larvae::RegisterTest("StackAllocator", "MarkerScopedPattern", []() {
+        comb::StackAllocator allocator{4_KB};
+
+        // Simulate scope pattern from documentation
+        auto marker1 = allocator.GetMarker();
+        void* data1 = allocator.Allocate(128, 8);
+        larvae::AssertNotNull(data1);
+
+        {
+            auto marker2 = allocator.GetMarker();
+            void* temp1 = allocator.Allocate(64, 8);
+            void* temp2 = allocator.Allocate(64, 8);
+            larvae::AssertNotNull(temp1);
+            larvae::AssertNotNull(temp2);
+
+            // Free inner scope
+            allocator.FreeToMarker(marker2);
+        }
+
+        // data1 space is still accounted for
+        larvae::AssertGreaterEqual(allocator.GetUsedMemory(), 128u);
+
+        // Free everything
+        allocator.FreeToMarker(marker1);
+        larvae::AssertEqual(allocator.GetUsedMemory(), 0u);
+    });
+
+    // =============================================================================
+    // Reset
+    // =============================================================================
+
+    auto test16 = larvae::RegisterTest("StackAllocator", "ResetFreesAllMemory", []() {
+        comb::StackAllocator allocator{1024};
+
+        static_cast<void>(allocator.Allocate(104, 8));
+        static_cast<void>(allocator.Allocate(104, 8));
+        static_cast<void>(allocator.Allocate(104, 8));
+
+        larvae::AssertEqual(allocator.GetUsedMemory(), 312u);
+
+        allocator.Reset();
+
+        larvae::AssertEqual(allocator.GetUsedMemory(), 0u);
+
+        // Should be able to allocate again
+        void* ptr = allocator.Allocate(104, 8);
+        larvae::AssertNotNull(ptr);
+    });
+
+    auto test17 = larvae::RegisterTest("StackAllocator", "ResetAllowsReuse", []() {
+        comb::StackAllocator allocator{256};
+
+        void* ptr1 = allocator.Allocate(100, 8);
+        void* ptr2 = allocator.Allocate(100, 8);
+
+        allocator.Reset();
+
+        void* ptr3 = allocator.Allocate(100, 8);
+        void* ptr4 = allocator.Allocate(100, 8);
+
+        larvae::AssertEqual(ptr1, ptr3);
+        larvae::AssertEqual(ptr2, ptr4);
+    });
+
+    // =============================================================================
+    // Deallocate (No-Op)
+    // =============================================================================
+
+    auto test18 = larvae::RegisterTest("StackAllocator", "DeallocateIsNoOp", []() {
+        comb::StackAllocator allocator{1024};
+
+        void* ptr = allocator.Allocate(100, 8);
+        size_t used_before = allocator.GetUsedMemory();
+
+        allocator.Deallocate(ptr);
+
+        size_t used_after = allocator.GetUsedMemory();
+
+        // Deallocate should not change used memory
+        larvae::AssertEqual(used_before, used_after);
+    });
+
+    auto test19 = larvae::RegisterTest("StackAllocator", "DeallocateNullptrIsSafe", []() {
+        comb::StackAllocator allocator{1024};
+
+        allocator.Deallocate(nullptr);
+
+        larvae::AssertTrue(true);
+    });
+
+    // =============================================================================
+    // Memory Access
+    // =============================================================================
+
+    auto test20 = larvae::RegisterTest("StackAllocator", "AllocatedMemoryIsWritable", []() {
+        comb::StackAllocator allocator{1024};
+
+        void* ptr = allocator.Allocate(256, 8);
+        auto* byte_ptr = static_cast<unsigned char*>(ptr);
+
+        std::memset(byte_ptr, 0x42, 256);
+
+        for (size_t i = 0; i < 256; ++i)
+        {
+            larvae::AssertEqual(byte_ptr[i], static_cast<unsigned char>(0x42));
+        }
+    });
+
+    auto test21 = larvae::RegisterTest("StackAllocator", "MultipleAllocationsAreIsolated", []() {
+        comb::StackAllocator allocator{1024};
+
+        void* ptr1 = allocator.Allocate(100, 8);
+        void* ptr2 = allocator.Allocate(100, 8);
+
+        auto* bytes1 = static_cast<unsigned char*>(ptr1);
+        auto* bytes2 = static_cast<unsigned char*>(ptr2);
+
+        std::memset(bytes1, 0xAA, 100);
+        std::memset(bytes2, 0xBB, 100);
+
+        larvae::AssertEqual(bytes1[0], static_cast<unsigned char>(0xAA));
+        larvae::AssertEqual(bytes1[99], static_cast<unsigned char>(0xAA));
+        larvae::AssertEqual(bytes2[0], static_cast<unsigned char>(0xBB));
+        larvae::AssertEqual(bytes2[99], static_cast<unsigned char>(0xBB));
+    });
+
+    // =============================================================================
+    // New/Delete
+    // =============================================================================
+
+    auto test22 = larvae::RegisterTest("StackAllocator", "NewConstructsObject", []() {
+        comb::StackAllocator allocator{1024};
+
+        struct TestObject
+        {
+            int value;
+            TestObject(int v) : value{v} {}
+        };
+
+        TestObject* obj = comb::New<TestObject>(allocator, 42);
+
+        larvae::AssertNotNull(obj);
+        larvae::AssertEqual(obj->value, 42);
+    });
+
+    auto test23 = larvae::RegisterTest("StackAllocator", "DeleteCallsDestructor", []() {
+        comb::StackAllocator allocator{1024};
+
+        struct TestObject
+        {
+            bool* destroyed;
+            TestObject(bool* d) : destroyed{d} { *destroyed = false; }
+            ~TestObject() { *destroyed = true; }
+        };
+
+        bool destroyed = false;
+        TestObject* obj = comb::New<TestObject>(allocator, &destroyed);
+
+        larvae::AssertFalse(destroyed);
+
+        comb::Delete(allocator, obj);
+
+        larvae::AssertTrue(destroyed);
+    });
+
+    // =============================================================================
+    // GetFreeMemory
+    // =============================================================================
+
+    auto test24 = larvae::RegisterTest("StackAllocator", "GetFreeMemoryReflectsUsage", []() {
+        comb::StackAllocator allocator{1024};
+
+        larvae::AssertEqual(allocator.GetFreeMemory(), 1024u);
+
+        static_cast<void>(allocator.Allocate(200, 8));
+        larvae::AssertEqual(allocator.GetFreeMemory(), 824u);
+
+        static_cast<void>(allocator.Allocate(300, 8));
+        larvae::AssertEqual(allocator.GetFreeMemory(), 524u);
+
+        allocator.Reset();
+        larvae::AssertEqual(allocator.GetFreeMemory(), 1024u);
+    });
+
+    auto test25 = larvae::RegisterTest("StackAllocator", "GetFreeMemoryWithMarkers", []() {
+        comb::StackAllocator allocator{1024};
+
+        static_cast<void>(allocator.Allocate(200, 8));
+        auto marker = allocator.GetMarker();
+
+        static_cast<void>(allocator.Allocate(400, 8));
+        larvae::AssertEqual(allocator.GetFreeMemory(), 424u);
+
+        allocator.FreeToMarker(marker);
+        larvae::AssertEqual(allocator.GetFreeMemory(), 824u);
+    });
+
+    // =============================================================================
+    // Move Semantics
+    // =============================================================================
+
+    auto test26 = larvae::RegisterTest("StackAllocator", "MoveConstructorTransfersOwnership", []() {
+        comb::StackAllocator allocator1{1024};
+        static_cast<void>(allocator1.Allocate(100, 8));
+
+        comb::StackAllocator allocator2{std::move(allocator1)};
+
+        larvae::AssertEqual(allocator2.GetUsedMemory(), 100u);
+        larvae::AssertEqual(allocator2.GetTotalMemory(), 1024u);
+        larvae::AssertStringEqual(allocator2.GetName(), "StackAllocator");
+    });
+
+    auto test27 = larvae::RegisterTest("StackAllocator", "MoveAssignmentTransfersOwnership", []() {
+        comb::StackAllocator allocator1{1024};
+        static_cast<void>(allocator1.Allocate(100, 8));
+
+        comb::StackAllocator allocator2{512};
+
+        allocator2 = std::move(allocator1);
+
+        larvae::AssertEqual(allocator2.GetUsedMemory(), 100u);
+        larvae::AssertEqual(allocator2.GetTotalMemory(), 1024u);
+    });
+
+    auto test28 = larvae::RegisterTest("StackAllocator", "MoveConstructorNullifiesSource", []() {
+        comb::StackAllocator allocator1{1024};
+        static_cast<void>(allocator1.Allocate(100, 8));
+
+        comb::StackAllocator allocator2{std::move(allocator1)};
+
+        // Source should be zeroed
+        larvae::AssertEqual(allocator1.GetTotalMemory(), 0u);
+        larvae::AssertEqual(allocator1.GetUsedMemory(), 0u);
+    });
+
+    // =============================================================================
+    // Performance
+    // =============================================================================
+
+    auto test29 = larvae::RegisterTest("StackAllocator", "ManySmallAllocations", []() {
+        comb::StackAllocator allocator{1_MB};
+
+        for (int i = 0; i < 10000; ++i)
+        {
+            void* ptr = allocator.Allocate(16, 8);
+            larvae::AssertNotNull(ptr);
+        }
+
+        larvae::AssertGreaterEqual(allocator.GetUsedMemory(), 160000u);
+    });
+
+    auto test30 = larvae::RegisterTest("StackAllocator", "RepeatedMarkerCycles", []() {
+        comb::StackAllocator allocator{4_KB};
+
+        for (int i = 0; i < 1000; ++i)
+        {
+            auto marker = allocator.GetMarker();
+
+            void* ptr = allocator.Allocate(64, 8);
+            larvae::AssertNotNull(ptr);
+
+            allocator.FreeToMarker(marker);
+        }
+
+        larvae::AssertEqual(allocator.GetUsedMemory(), 0u);
+    });
+}

--- a/Comb/tests/test_thread_safe.cpp
+++ b/Comb/tests/test_thread_safe.cpp
@@ -1,0 +1,329 @@
+#include <larvae/larvae.h>
+#include <comb/thread_safe_allocator.h>
+#include <comb/buddy_allocator.h>
+#include <comb/linear_allocator.h>
+#include <comb/new.h>
+#include <thread>
+
+namespace
+{
+    constexpr size_t operator""_KB(unsigned long long kb) { return kb * 1024; }
+    constexpr size_t operator""_MB(unsigned long long mb) { return mb * 1024 * 1024; }
+
+    // =============================================================================
+    // Concept Satisfaction
+    // =============================================================================
+
+    auto test1 = larvae::RegisterTest("ThreadSafeAllocator", "ConceptSatisfaction", []() {
+        larvae::AssertTrue((comb::Allocator<comb::ThreadSafeAllocator<comb::BuddyAllocator>>));
+        larvae::AssertTrue((comb::Allocator<comb::ThreadSafeAllocator<comb::LinearAllocator>>));
+    });
+
+    // =============================================================================
+    // Basic Delegation
+    // =============================================================================
+
+    auto test2 = larvae::RegisterTest("ThreadSafeAllocator", "AllocateDelegates", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        void* ptr = safe.Allocate(64, 8);
+        larvae::AssertNotNull(ptr);
+
+        // Used memory should be reflected
+        larvae::AssertTrue(safe.GetUsedMemory() > 0);
+
+        safe.Deallocate(ptr);
+        larvae::AssertEqual(safe.GetUsedMemory(), 0u);
+    });
+
+    auto test3 = larvae::RegisterTest("ThreadSafeAllocator", "DeallocateDelegates", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        void* ptr = safe.Allocate(128, 8);
+        larvae::AssertNotNull(ptr);
+        larvae::AssertTrue(safe.GetUsedMemory() > 0);
+
+        safe.Deallocate(ptr);
+        larvae::AssertEqual(safe.GetUsedMemory(), 0u);
+    });
+
+    auto test4 = larvae::RegisterTest("ThreadSafeAllocator", "GetNameReturnsCorrectName", []() {
+        comb::BuddyAllocator buddy{1_KB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        larvae::AssertStringEqual(safe.GetName(), "ThreadSafeAllocator");
+    });
+
+    auto test5 = larvae::RegisterTest("ThreadSafeAllocator", "GetUsedMemoryDelegates", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        larvae::AssertEqual(safe.GetUsedMemory(), 0u);
+
+        void* ptr = safe.Allocate(100, 8);
+        larvae::AssertNotNull(ptr);
+
+        // ThreadSafe reports same as underlying
+        larvae::AssertEqual(safe.GetUsedMemory(), buddy.GetUsedMemory());
+
+        safe.Deallocate(ptr);
+    });
+
+    auto test6 = larvae::RegisterTest("ThreadSafeAllocator", "GetTotalMemoryDelegates", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        larvae::AssertEqual(safe.GetTotalMemory(), buddy.GetTotalMemory());
+        larvae::AssertEqual(safe.GetTotalMemory(), 1_MB);
+    });
+
+    // =============================================================================
+    // Underlying Access
+    // =============================================================================
+
+    auto test7 = larvae::RegisterTest("ThreadSafeAllocator", "UnderlyingReturnsReferenceToAllocator", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        comb::BuddyAllocator& ref = safe.Underlying();
+        larvae::AssertEqual(&ref, &buddy);
+    });
+
+    auto test8 = larvae::RegisterTest("ThreadSafeAllocator", "ConstUnderlyingReturnsConstReference", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        const comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        const comb::BuddyAllocator& ref = safe.Underlying();
+        larvae::AssertEqual(&ref, &buddy);
+    });
+
+    // =============================================================================
+    // New/Delete Through Wrapper
+    // =============================================================================
+
+    auto test9 = larvae::RegisterTest("ThreadSafeAllocator", "NewDeleteWorks", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        struct TestObject
+        {
+            int value;
+            TestObject(int v) : value{v} {}
+        };
+
+        TestObject* obj = comb::New<TestObject>(safe, 42);
+        larvae::AssertNotNull(obj);
+        larvae::AssertEqual(obj->value, 42);
+
+        comb::Delete(safe, obj);
+        larvae::AssertEqual(safe.GetUsedMemory(), 0u);
+    });
+
+    auto test10 = larvae::RegisterTest("ThreadSafeAllocator", "DeleteCallsDestructor", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        struct TestObject
+        {
+            bool* destroyed;
+            TestObject(bool* d) : destroyed{d} { *destroyed = false; }
+            ~TestObject() { *destroyed = true; }
+        };
+
+        bool destroyed = false;
+        TestObject* obj = comb::New<TestObject>(safe, &destroyed);
+        larvae::AssertFalse(destroyed);
+
+        comb::Delete(safe, obj);
+        larvae::AssertTrue(destroyed);
+    });
+
+    // =============================================================================
+    // Move Semantics
+    // =============================================================================
+
+    auto test11 = larvae::RegisterTest("ThreadSafeAllocator", "MoveConstructor", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe1{buddy};
+
+        void* ptr = safe1.Allocate(64, 8);
+        larvae::AssertNotNull(ptr);
+
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe2{std::move(safe1)};
+
+        // safe2 now wraps the buddy allocator
+        larvae::AssertTrue(safe2.GetUsedMemory() > 0);
+        larvae::AssertEqual(&safe2.Underlying(), &buddy);
+
+        safe2.Deallocate(ptr);
+        larvae::AssertEqual(safe2.GetUsedMemory(), 0u);
+    });
+
+    auto test12 = larvae::RegisterTest("ThreadSafeAllocator", "MoveAssignment", []() {
+        comb::BuddyAllocator buddy1{1_MB};
+        comb::BuddyAllocator buddy2{512_KB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe1{buddy1};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe2{buddy2};
+
+        void* ptr = safe1.Allocate(64, 8);
+        larvae::AssertNotNull(ptr);
+
+        safe2 = std::move(safe1);
+
+        // safe2 now points to buddy1
+        larvae::AssertEqual(&safe2.Underlying(), &buddy1);
+        larvae::AssertTrue(safe2.GetUsedMemory() > 0);
+
+        safe2.Deallocate(ptr);
+    });
+
+    // =============================================================================
+    // Multiple Allocations
+    // =============================================================================
+
+    auto test13 = larvae::RegisterTest("ThreadSafeAllocator", "MultipleAllocationsAndDeallocations", []() {
+        comb::BuddyAllocator buddy{1_MB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        void* ptrs[10];
+        for (int i = 0; i < 10; ++i)
+        {
+            ptrs[i] = safe.Allocate(64, 8);
+            larvae::AssertNotNull(ptrs[i]);
+        }
+
+        larvae::AssertTrue(safe.GetUsedMemory() > 0);
+
+        for (int i = 0; i < 10; ++i)
+        {
+            safe.Deallocate(ptrs[i]);
+        }
+
+        larvae::AssertEqual(safe.GetUsedMemory(), 0u);
+    });
+
+    auto test14 = larvae::RegisterTest("ThreadSafeAllocator", "OOMReturnsNull", []() {
+        comb::BuddyAllocator buddy{1_KB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        void* ptr1 = safe.Allocate(1000, 8);
+        larvae::AssertNotNull(ptr1);
+
+        void* ptr2 = safe.Allocate(64, 8);
+        larvae::AssertNull(ptr2);
+
+        safe.Deallocate(ptr1);
+    });
+
+    // =============================================================================
+    // Concurrent Access
+    // =============================================================================
+
+    auto test15 = larvae::RegisterTest("ThreadSafeAllocator", "ConcurrentAllocations", []() {
+        comb::BuddyAllocator buddy{16_MB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        constexpr int kThreadCount = 4;
+        constexpr int kAllocsPerThread = 100;
+
+        void* ptrs[kThreadCount][kAllocsPerThread]{};
+        bool success[kThreadCount]{};
+
+        auto worker = [&](int threadIndex) {
+            bool ok = true;
+            for (int i = 0; i < kAllocsPerThread; ++i)
+            {
+                ptrs[threadIndex][i] = safe.Allocate(64, 8);
+                if (ptrs[threadIndex][i] == nullptr)
+                {
+                    ok = false;
+                    break;
+                }
+            }
+            success[threadIndex] = ok;
+        };
+
+        std::thread threads[kThreadCount];
+        for (int t = 0; t < kThreadCount; ++t)
+        {
+            threads[t] = std::thread(worker, t);
+        }
+
+        for (int t = 0; t < kThreadCount; ++t)
+        {
+            threads[t].join();
+        }
+
+        // All threads should succeed
+        for (int t = 0; t < kThreadCount; ++t)
+        {
+            larvae::AssertTrue(success[t]);
+        }
+
+        // Deallocate all
+        for (int t = 0; t < kThreadCount; ++t)
+        {
+            for (int i = 0; i < kAllocsPerThread; ++i)
+            {
+                if (ptrs[t][i] != nullptr)
+                {
+                    safe.Deallocate(ptrs[t][i]);
+                }
+            }
+        }
+
+        larvae::AssertEqual(safe.GetUsedMemory(), 0u);
+    });
+
+    auto test16 = larvae::RegisterTest("ThreadSafeAllocator", "ConcurrentAllocAndDealloc", []() {
+        comb::BuddyAllocator buddy{16_MB};
+        comb::ThreadSafeAllocator<comb::BuddyAllocator> safe{buddy};
+
+        constexpr int kThreadCount = 4;
+        constexpr int kCycles = 200;
+
+        auto worker = [&]() {
+            for (int i = 0; i < kCycles; ++i)
+            {
+                void* ptr = safe.Allocate(128, 8);
+                if (ptr != nullptr)
+                {
+                    safe.Deallocate(ptr);
+                }
+            }
+        };
+
+        std::thread threads[kThreadCount];
+        for (int t = 0; t < kThreadCount; ++t)
+        {
+            threads[t] = std::thread(worker);
+        }
+
+        for (int t = 0; t < kThreadCount; ++t)
+        {
+            threads[t].join();
+        }
+
+        larvae::AssertEqual(safe.GetUsedMemory(), 0u);
+    });
+
+    // =============================================================================
+    // With LinearAllocator
+    // =============================================================================
+
+    auto test17 = larvae::RegisterTest("ThreadSafeAllocator", "WorksWithLinearAllocator", []() {
+        comb::LinearAllocator linear{1_MB};
+        comb::ThreadSafeAllocator<comb::LinearAllocator> safe{linear};
+
+        void* ptr1 = safe.Allocate(64, 8);
+        void* ptr2 = safe.Allocate(128, 16);
+
+        larvae::AssertNotNull(ptr1);
+        larvae::AssertNotNull(ptr2);
+
+        larvae::AssertTrue(safe.GetUsedMemory() > 0);
+        larvae::AssertEqual(safe.GetTotalMemory(), 1_MB);
+    });
+}

--- a/Hive/include/hive/core/log.h
+++ b/Hive/include/hive/core/log.h
@@ -89,7 +89,7 @@ namespace hive
 
     inline void LogGeneral(const LogCategory &cat, LogSeverity sev, const char *msg)
     {
-        Assert(LogManager::IsInitialized(), "LogManager not initialized");
+        if (!LogManager::IsInitialized()) return;
         LogManager::GetInstance().Log(cat, sev, msg);
     }
 

--- a/Queen/include/queen/command/commands.h
+++ b/Queen/include/queen/command/commands.h
@@ -223,15 +223,7 @@ namespace queen
     private:
         CommandBuffer<Allocator>& CreateBuffer(std::thread::id id)
         {
-            // If we have room in pre-allocated buffers, use it
-            if (buffer_count_ < thread_buffers_.Size())
-            {
-                thread_buffers_[buffer_count_].thread_id = id;
-                return thread_buffers_[buffer_count_++].buffer;
-            }
-
-            // Otherwise allocate a new buffer
-            thread_buffers_.PushBack(ThreadBuffer{id, *allocator_});
+            thread_buffers_.EmplaceBack(id, *allocator_);
             return thread_buffers_[buffer_count_++].buffer;
         }
 

--- a/Queen/include/queen/core/component_mask.h
+++ b/Queen/include/queen/core/component_mask.h
@@ -4,7 +4,6 @@
 #include <wax/containers/vector.h>
 #include <hive/core/assert.h>
 #include <cstdint>
-#include <cstring>
 
 namespace queen
 {

--- a/Queen/include/queen/core/entity_allocator.h
+++ b/Queen/include/queen/core/entity_allocator.h
@@ -27,7 +27,7 @@ namespace queen
      * - Memory: O(max_allocated_entities)
      *
      * Limitations:
-     * - Generation wraps after 65536 deallocations of same index
+     * - Generation wraps at 65536 deallocations of same index (rare false positives)
      * - Not thread-safe
      * - Generations array grows monotonically (never shrinks)
      *
@@ -89,10 +89,7 @@ namespace queen
             uint32_t index = entity.Index();
 
             Entity::GenerationType& gen = generations_[index];
-            if (gen < Entity::kMaxGeneration)
-            {
-                ++gen;
-            }
+            ++gen;
 
             free_list_.PushBack(index);
         }

--- a/Queen/include/queen/event/event.h
+++ b/Queen/include/queen/event/event.h
@@ -98,11 +98,6 @@ namespace queen
             return value_ == other.value_;
         }
 
-        [[nodiscard]] constexpr bool operator!=(const EventId& other) const noexcept
-        {
-            return value_ != other.value_;
-        }
-
         [[nodiscard]] constexpr bool IsValid() const noexcept
         {
             return value_ != 0;

--- a/Queen/include/queen/event/events.h
+++ b/Queen/include/queen/event/events.h
@@ -214,13 +214,11 @@ namespace queen
         {
             TypeId id = TypeIdOf<T>();
 
-            // Try to find existing queue
-            if (auto* entry = queues_.Find(id))
+            if (auto* index = queues_.Find(id))
             {
-                return *static_cast<EventQueue<T, Allocator>*>((*entry)->queue);
+                return *static_cast<EventQueue<T, Allocator>*>(entries_[*index].queue);
             }
 
-            // Create new queue
             void* memory = allocator_->Allocate(sizeof(EventQueue<T, Allocator>), alignof(EventQueue<T, Allocator>));
             hive::Assert(memory != nullptr, "Failed to allocate EventQueue");
 
@@ -239,14 +237,15 @@ namespace queen
             };
             entry.type_id = id;
 
+            size_t new_index = entries_.Size();
             entries_.PushBack(entry);
-            queues_.Insert(id, &entries_.Back());
+            queues_.Insert(id, new_index);
 
             return *queue;
         }
 
         Allocator* allocator_;
-        wax::HashMap<TypeId, QueueEntry*, Allocator> queues_;
+        wax::HashMap<TypeId, size_t, Allocator> queues_;
         wax::Vector<QueueEntry, Allocator> entries_;
     };
 }

--- a/Queen/include/queen/hierarchy/parent.h
+++ b/Queen/include/queen/hierarchy/parent.h
@@ -60,10 +60,5 @@ namespace queen
         {
             return entity == other.entity;
         }
-
-        [[nodiscard]] bool operator!=(const Parent& other) const noexcept
-        {
-            return entity != other.entity;
-        }
     };
 }

--- a/Queen/include/queen/observer/observer.h
+++ b/Queen/include/queen/observer/observer.h
@@ -30,11 +30,6 @@ namespace queen
             return value_ == other.value_;
         }
 
-        [[nodiscard]] constexpr bool operator!=(ObserverId other) const noexcept
-        {
-            return value_ != other.value_;
-        }
-
     private:
         uint32_t value_;
     };

--- a/Queen/include/queen/observer/observer.h
+++ b/Queen/include/queen/observer/observer.h
@@ -106,11 +106,13 @@ namespace queen
     {
     public:
         static constexpr size_t kMaxNameLength = 63;
+        static constexpr size_t kMaxFilters = 4;
 
         Observer(Allocator& allocator, ObserverId id, const char* name, TriggerType trigger, TypeId component_id)
             : id_{id}
             , trigger_{trigger}
             , enabled_{true}
+            , filter_count_{0}
             , component_id_{component_id}
             , callback_fn_{nullptr}
             , user_data_{nullptr}
@@ -149,6 +151,7 @@ namespace queen
             : id_{other.id_}
             , trigger_{other.trigger_}
             , enabled_{other.enabled_}
+            , filter_count_{other.filter_count_}
             , component_id_{other.component_id_}
             , callback_fn_{other.callback_fn_}
             , user_data_{other.user_data_}
@@ -156,6 +159,7 @@ namespace queen
             , allocator_{other.allocator_}
         {
             std::memcpy(name_, other.name_, sizeof(name_));
+            std::memcpy(filter_ids_, other.filter_ids_, sizeof(TypeId) * filter_count_);
             other.user_data_ = nullptr;
             other.destructor_fn_ = nullptr;
         }
@@ -176,8 +180,10 @@ namespace queen
                 id_ = other.id_;
                 trigger_ = other.trigger_;
                 enabled_ = other.enabled_;
+                filter_count_ = other.filter_count_;
                 component_id_ = other.component_id_;
                 std::memcpy(name_, other.name_, sizeof(name_));
+                std::memcpy(filter_ids_, other.filter_ids_, sizeof(TypeId) * filter_count_);
                 callback_fn_ = other.callback_fn_;
                 user_data_ = other.user_data_;
                 destructor_fn_ = other.destructor_fn_;
@@ -212,6 +218,18 @@ namespace queen
         {
             enabled_ = enabled;
         }
+
+        void AddFilter(TypeId type_id) noexcept
+        {
+            if (filter_count_ < kMaxFilters)
+            {
+                filter_ids_[filter_count_++] = type_id;
+            }
+        }
+
+        [[nodiscard]] bool HasFilters() const noexcept { return filter_count_ > 0; }
+        [[nodiscard]] uint8_t FilterCount() const noexcept { return filter_count_; }
+        [[nodiscard]] TypeId FilterId(uint8_t index) const noexcept { return filter_ids_[index]; }
 
         void SetCallback(ObserverCallbackFn fn, void* user_data, void (*destructor)(void*))
         {
@@ -256,8 +274,9 @@ namespace queen
         ObserverId id_;
         TriggerType trigger_;
         bool enabled_;
-        // 2 bytes padding
+        uint8_t filter_count_;
         TypeId component_id_;
+        TypeId filter_ids_[kMaxFilters];
         ObserverCallbackFn callback_fn_;
         void* user_data_;
         void (*destructor_fn_)(void*);

--- a/Queen/include/queen/observer/observer_builder.h
+++ b/Queen/include/queen/observer/observer_builder.h
@@ -100,10 +100,7 @@ namespace queen
         template<typename T>
         ObserverBuilder& With()
         {
-            // Store filter component type for matching
-            // This would require filter support in Observer
-            // For now, this is a placeholder for future expansion
-            (void)TypeIdOf<T>();
+            static_assert(sizeof(T) == 0, "Observer::With<T>() filter is not yet implemented");
             return *this;
         }
 

--- a/Queen/include/queen/observer/observer_builder.h
+++ b/Queen/include/queen/observer/observer_builder.h
@@ -100,7 +100,7 @@ namespace queen
         template<typename T>
         ObserverBuilder& With()
         {
-            static_assert(sizeof(T) == 0, "Observer::With<T>() filter is not yet implemented");
+            observer_->AddFilter(TypeIdOf<T>());
             return *this;
         }
 

--- a/Queen/include/queen/observer/observer_event.h
+++ b/Queen/include/queen/observer/observer_event.h
@@ -237,11 +237,6 @@ namespace queen
             return trigger == other.trigger && component_id == other.component_id;
         }
 
-        [[nodiscard]] constexpr bool operator!=(const ObserverKey& other) const noexcept
-        {
-            return !(*this == other);
-        }
-
         /**
          * Create key from compile-time trigger type
          */

--- a/Queen/include/queen/observer/observer_storage.h
+++ b/Queen/include/queen/observer/observer_storage.h
@@ -172,26 +172,7 @@ namespace queen
          * @param component Pointer to component data (may be nullptr for OnRemove)
          */
         void Trigger(TriggerType trigger, TypeId component_id,
-                    World& world, Entity entity, const void* component)
-        {
-            ObserverKey key{trigger, component_id};
-
-            auto* indices = lookup_.Find(key);
-            if (indices == nullptr)
-            {
-                return; // No observers for this key
-            }
-
-            // Invoke all matching observers
-            for (size_t i = 0; i < indices->Size(); ++i)
-            {
-                uint32_t idx = (*indices)[i];
-                if (idx < observers_.Size())
-                {
-                    observers_[idx].Invoke(world, entity, component);
-                }
-            }
-        }
+                    World& world, Entity entity, const void* component); // Defined in observer_storage_impl.h
 
         /**
          * Trigger all observers matching a trigger event type

--- a/Queen/include/queen/observer/observer_storage_impl.h
+++ b/Queen/include/queen/observer/observer_storage_impl.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <queen/observer/observer_storage.h>
+#include <queen/world/world.h>
+
+namespace queen
+{
+    template<comb::Allocator Allocator>
+    void ObserverStorage<Allocator>::Trigger(TriggerType trigger, TypeId component_id,
+                                            World& world, Entity entity, const void* component)
+    {
+        ObserverKey key{trigger, component_id};
+
+        auto* indices = lookup_.Find(key);
+        if (indices == nullptr)
+        {
+            return;
+        }
+
+        for (size_t i = 0; i < indices->Size(); ++i)
+        {
+            uint32_t idx = (*indices)[i];
+            if (idx < observers_.Size())
+            {
+                auto& observer = observers_[idx];
+
+                // Check filter components before invoking
+                if (observer.HasFilters())
+                {
+                    bool matches = true;
+                    for (uint8_t f = 0; f < observer.FilterCount(); ++f)
+                    {
+                        if (!world.HasComponent(entity, observer.FilterId(f)))
+                        {
+                            matches = false;
+                            break;
+                        }
+                    }
+                    if (!matches) continue;
+                }
+
+                observer.Invoke(world, entity, component);
+            }
+        }
+    }
+}

--- a/Queen/include/queen/query/query.h
+++ b/Queen/include/queen/query/query.h
@@ -88,8 +88,7 @@ namespace queen
         template<typename... Terms>
         constexpr bool HasChangeFilterV = HasChangeFilter<Terms...>::value;
 
-        // Get ticks pointer for a change filter term
-        template<typename Allocator, typename Archetype, typename ChangeFilterTerm>
+        template<typename Archetype, typename ChangeFilterTerm>
         const ComponentTicks* GetTicksPtr(Archetype* arch)
         {
             using ComponentT = typename ChangeFilterTerm::ComponentType;
@@ -97,11 +96,6 @@ namespace queen
             if (column == nullptr) return nullptr;
             return column->TicksData();
         }
-
-        // Forward declaration
-        template<size_t I, typename TicksTuple, typename... ChangeFilterTerms>
-        bool CheckAllFiltersImpl(const TicksTuple& ticks_ptrs, size_t row, Tick last_run,
-                                 std::tuple<ChangeFilterTerms...>);
 
         template<size_t I, typename TicksTuple, typename... ChangeFilterTerms>
         bool CheckAllFiltersImpl(const TicksTuple& ticks_ptrs, size_t row, Tick last_run,
@@ -144,7 +138,7 @@ namespace queen
             {
                 // Get ticks for each change filter component
                 auto ticks_ptrs = std::make_tuple(
-                    GetTicksPtr<Allocator, Archetype, ChangeFilterTerms>(arch)...
+                    GetTicksPtr<Archetype, ChangeFilterTerms>(arch)...
                 );
 
                 // Check all filters

--- a/Queen/include/queen/query/query_term.h
+++ b/Queen/include/queen/query/query_term.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <queen/core/type_id.h>
-#include <queen/core/entity.h>
 #include <cstdint>
 
 namespace queen

--- a/Queen/include/queen/reflect/component_registry.h
+++ b/Queen/include/queen/reflect/component_registry.h
@@ -203,28 +203,9 @@ namespace queen
 
             for (size_t i = 0; i < count_; ++i)
             {
-                if (entries_[i].reflection.name != nullptr)
+                if (detail::StringsEqual(entries_[i].reflection.name, name))
                 {
-                    // Simple string compare
-                    const char* a = entries_[i].reflection.name;
-                    const char* b = name;
-                    bool equal = true;
-
-                    while (*a && *b)
-                    {
-                        if (*a != *b)
-                        {
-                            equal = false;
-                            break;
-                        }
-                        ++a;
-                        ++b;
-                    }
-
-                    if (equal && *a == *b)
-                    {
-                        return &entries_[i];
-                    }
+                    return &entries_[i];
                 }
             }
 

--- a/Queen/include/queen/reflect/field_info.h
+++ b/Queen/include/queen/reflect/field_info.h
@@ -66,13 +66,35 @@ namespace queen
      *   void* field_ptr = static_cast<std::byte*>(component_ptr) + info.offset;
      * @endcode
      */
+    namespace detail
+    {
+        /**
+         * Constexpr-safe string comparison (no <cstring> dependency)
+         */
+        constexpr bool StringsEqual(const char* a, const char* b) noexcept
+        {
+            if (a == b) return true;
+            if (a == nullptr || b == nullptr) return false;
+
+            while (*a && *b)
+            {
+                if (*a != *b) return false;
+                ++a;
+                ++b;
+            }
+            return *a == *b;
+        }
+    }
+
     struct FieldInfo
     {
         const char* name = nullptr;
         size_t offset = 0;
         size_t size = 0;
         FieldType type = FieldType::Invalid;
-        TypeId nested_type_id = 0;  // For FieldType::Struct, the TypeId of the nested type
+        TypeId nested_type_id = 0;          // For FieldType::Struct, the TypeId of the nested type
+        const FieldInfo* nested_fields = nullptr;   // For Struct: field layout of the nested type
+        size_t nested_field_count = 0;              // For Struct: number of nested fields
 
         [[nodiscard]] constexpr bool IsValid() const noexcept
         {

--- a/Queen/include/queen/scheduler/parallel.h
+++ b/Queen/include/queen/scheduler/parallel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <queen/scheduler/thread_pool.h>
+#include <hive/core/assert.h>
 #include <atomic>
 #include <cstddef>
 

--- a/Queen/include/queen/scheduler/parallel.h
+++ b/Queen/include/queen/scheduler/parallel.h
@@ -109,11 +109,12 @@ namespace queen
      *
      * Example:
      * @code
-     *   std::vector<int> data(1000);
+     *   wax::Vector<int, Alloc> data{alloc};
+     *   data.Resize(1000);
      *
-     *   parallel_for(pool, 0, data.size(),
+     *   parallel_for(pool, 0, data.Size(),
      *       [](size_t i, void* ud) {
-     *           auto* vec = static_cast<std::vector<int>*>(ud);
+     *           auto* vec = static_cast<wax::Vector<int, Alloc>*>(ud);
      *           (*vec)[i] = static_cast<int>(i * 2);
      *       }, &data);
      * @endcode
@@ -164,12 +165,12 @@ namespace queen
                 WaitGroup* wg;
             };
 
-            // We need to allocate ChunkData somewhere - use a static approach for simplicity
-            // In production, this would use an allocator
-            thread_local ChunkData chunks[1024];
+                static constexpr size_t kMaxChunks = 1024;
+            thread_local ChunkData chunks[kMaxChunks];
             thread_local size_t chunk_idx = 0;
 
-            auto& cd = chunks[chunk_idx % 1024];
+            hive::Assert(num_chunks <= kMaxChunks, "parallel_for: too many chunks, increase kMaxChunks or chunk_size");
+            auto& cd = chunks[chunk_idx % kMaxChunks];
             chunk_idx++;
 
             cd.func = func;
@@ -252,10 +253,11 @@ namespace queen
                 WaitGroup* wg;
             };
 
-            thread_local WrappedTask wrapped_tasks[1024];
+            static constexpr size_t kMaxWrapped = 1024;
+            thread_local WrappedTask wrapped_tasks[kMaxWrapped];
             thread_local size_t wrapped_idx = 0;
 
-            auto& wt = wrapped_tasks[wrapped_idx % 1024];
+            auto& wt = wrapped_tasks[wrapped_idx % kMaxWrapped];
             wrapped_idx++;
 
             wt.func = func;

--- a/Queen/include/queen/scheduler/parallel_scheduler.h
+++ b/Queen/include/queen/scheduler/parallel_scheduler.h
@@ -247,11 +247,12 @@ namespace queen
                 WaitGroup* wg;
             };
 
-            // Use thread-local storage for task data (simple approach)
-            thread_local TaskData tasks[256];
+            static constexpr size_t kMaxTasks = 256;
+            thread_local TaskData tasks[kMaxTasks];
             thread_local size_t task_idx = 0;
 
-            auto& td = tasks[task_idx % 256];
+            hive::Assert(task_idx < kMaxTasks, "ParallelScheduler: too many concurrent tasks");
+            auto& td = tasks[task_idx % kMaxTasks];
             task_idx++;
 
             td.scheduler = this;

--- a/Queen/include/queen/scheduler/parallel_scheduler.h
+++ b/Queen/include/queen/scheduler/parallel_scheduler.h
@@ -6,6 +6,7 @@
 #include <queen/system/system_storage.h>
 #include <queen/core/tick.h>
 #include <comb/allocator_concepts.h>
+#include <hive/core/assert.h>
 #include <atomic>
 
 namespace queen

--- a/Queen/include/queen/scheduler/system_node.h
+++ b/Queen/include/queen/scheduler/system_node.h
@@ -68,6 +68,12 @@ namespace queen
             unfinished_deps_ = count;
         }
 
+        constexpr void IncrementDependencyCount() noexcept
+        {
+            ++dependency_count_;
+            ++unfinished_deps_;
+        }
+
         /**
          * Reset to pending state for a new frame
          */

--- a/Queen/include/queen/scheduler/thread_pool.h
+++ b/Queen/include/queen/scheduler/thread_pool.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <thread>
 #include <mutex>
+#include <condition_variable>
 
 namespace queen
 {
@@ -249,6 +250,9 @@ namespace queen
                 workers_[i].should_stop.store(true, std::memory_order_release);
             }
 
+            // Wake all parked workers so they see should_stop
+            park_cv_.notify_all();
+
             // Wait for all workers to finish
             for (size_t i = 0; i < worker_count_; ++i)
             {
@@ -279,6 +283,12 @@ namespace queen
             {
                 std::lock_guard<std::mutex> lock{submit_mutex_};
                 global_queue_->Push(task);
+            }
+
+            // Wake a parked worker if using Park strategy
+            if (idle_strategy_ == IdleStrategy::Park)
+            {
+                park_cv_.notify_one();
             }
         }
 
@@ -479,10 +489,14 @@ namespace queen
                 break;
 
             case IdleStrategy::Park:
-                // TODO: Use condition variable for true parking
-                // For now, just yield
-                std::this_thread::yield();
+            {
+                std::unique_lock<std::mutex> lock{park_mutex_};
+                park_cv_.wait_for(lock, std::chrono::milliseconds(1), [this] {
+                    return pending_tasks_.load(std::memory_order_acquire) > 0
+                        || !running_.load(std::memory_order_acquire);
+                });
                 break;
+            }
             }
         }
 
@@ -491,6 +505,8 @@ namespace queen
         WorkerContext* workers_;
         WorkStealingDeque<Task, SafeAllocator>* global_queue_;  // Main submission queue
         mutable std::mutex submit_mutex_;  // Protects global_queue_ Push (multi-producer)
+        std::condition_variable park_cv_;   // Wakes parked workers
+        std::mutex park_mutex_;             // Protects park_cv_
         size_t worker_count_;
         IdleStrategy idle_strategy_;
         std::atomic<bool> running_;

--- a/Queen/include/queen/scheduler/thread_pool.h
+++ b/Queen/include/queen/scheduler/thread_pool.h
@@ -6,8 +6,6 @@
 #include <comb/thread_safe_allocator.h>
 #include <atomic>
 #include <thread>
-#include <functional>
-#include <random>
 #include <mutex>
 
 namespace queen
@@ -154,7 +152,6 @@ namespace queen
             , idle_strategy_{idle_strategy}
             , running_{false}
             , pending_tasks_{0}
-            , next_worker_{0}
         {
             // Allocate global submission queue
             // The deque uses safe_allocator_ internally for Grow() which can happen from any thread
@@ -498,6 +495,5 @@ namespace queen
         IdleStrategy idle_strategy_;
         std::atomic<bool> running_;
         std::atomic<int64_t> pending_tasks_;
-        std::atomic<size_t> next_worker_;
     };
 }

--- a/Queen/include/queen/storage/archetype.h
+++ b/Queen/include/queen/storage/archetype.h
@@ -8,7 +8,6 @@
 #include <wax/containers/vector.h>
 #include <wax/containers/hash_map.h>
 #include <hive/core/assert.h>
-#include <algorithm>
 #include <type_traits>
 
 namespace queen
@@ -20,11 +19,11 @@ namespace queen
         template<comb::Allocator Allocator>
         ArchetypeId ComputeArchetypeId(const wax::Vector<TypeId, Allocator>& sorted_types)
         {
-            ArchetypeId hash = 14695981039346656037ULL;
+            ArchetypeId hash = kFnv1aOffset;
             for (size_t i = 0; i < sorted_types.Size(); ++i)
             {
                 hash ^= sorted_types[i];
-                hash *= 1099511628211ULL;
+                hash *= kFnv1aPrime;
             }
             return hash;
         }

--- a/Queen/include/queen/storage/archetype_graph.h
+++ b/Queen/include/queen/storage/archetype_graph.h
@@ -4,6 +4,7 @@
 #include <queen/core/component_info.h>
 #include <queen/storage/archetype.h>
 #include <comb/allocator_concepts.h>
+#include <comb/new.h>
 #include <wax/containers/vector.h>
 #include <wax/containers/hash_map.h>
 

--- a/Queen/include/queen/storage/archetype_graph.h
+++ b/Queen/include/queen/storage/archetype_graph.h
@@ -73,8 +73,32 @@ namespace queen
 
         ArchetypeGraph(const ArchetypeGraph&) = delete;
         ArchetypeGraph& operator=(const ArchetypeGraph&) = delete;
-        ArchetypeGraph(ArchetypeGraph&&) = default;
-        ArchetypeGraph& operator=(ArchetypeGraph&&) = default;
+
+        ArchetypeGraph(ArchetypeGraph&& other) noexcept
+            : allocator_{other.allocator_}
+            , archetypes_{static_cast<wax::HashMap<ArchetypeId, Archetype<Allocator>*, Allocator>&&>(other.archetypes_)}
+            , archetype_storage_{static_cast<wax::Vector<Archetype<Allocator>*, Allocator>&&>(other.archetype_storage_)}
+            , empty_archetype_{other.empty_archetype_}
+        {
+            other.empty_archetype_ = nullptr;
+        }
+
+        ArchetypeGraph& operator=(ArchetypeGraph&& other) noexcept
+        {
+            if (this != &other)
+            {
+                for (size_t i = 0; i < archetype_storage_.Size(); ++i)
+                {
+                    comb::Delete(*allocator_, archetype_storage_[i]);
+                }
+                allocator_ = other.allocator_;
+                archetypes_ = static_cast<wax::HashMap<ArchetypeId, Archetype<Allocator>*, Allocator>&&>(other.archetypes_);
+                archetype_storage_ = static_cast<wax::Vector<Archetype<Allocator>*, Allocator>&&>(other.archetype_storage_);
+                empty_archetype_ = other.empty_archetype_;
+                other.empty_archetype_ = nullptr;
+            }
+            return *this;
+        }
 
         [[nodiscard]] Archetype<Allocator>* GetEmptyArchetype() noexcept
         {

--- a/Queen/include/queen/storage/column.h
+++ b/Queen/include/queen/storage/column.h
@@ -217,15 +217,22 @@ namespace queen
                     std::memcpy(dst, src, meta_.size);
                 }
 
-                // Move ticks from last element to swapped position
+                if (meta_.destruct != nullptr)
+                {
+                    meta_.destruct(src);
+                }
+
                 ticks_[index] = ticks_[size_ - 1];
+            }
+            else
+            {
+                if (meta_.destruct != nullptr)
+                {
+                    meta_.destruct(GetRaw(index));
+                }
             }
 
             --size_;
-            if (meta_.destruct != nullptr && index == size_)
-            {
-                meta_.destruct(GetRaw(size_));
-            }
         }
 
         [[nodiscard]] void* GetRaw(size_t index) noexcept

--- a/Queen/include/queen/storage/table.h
+++ b/Queen/include/queen/storage/table.h
@@ -291,6 +291,8 @@ namespace queen
                     {
                         std::memcpy(dst, src, meta.size);
                     }
+
+                    dst_col->GetTicks(dest_row) = src_col.GetTicks(source_row);
                     ++moved_count;
                 }
             }

--- a/Queen/include/queen/system/resource_param.h
+++ b/Queen/include/queen/system/resource_param.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <queen/core/type_id.h>
-#include <hive/core/assert.h>
 
 namespace queen
 {
@@ -50,12 +49,7 @@ namespace queen
         static constexpr TypeId type_id = TypeIdOf<T>();
         static constexpr bool is_mutable = false;
 
-        constexpr Res() noexcept : ptr_{nullptr} {}
-
-        explicit constexpr Res(const T* ptr) noexcept : ptr_{ptr}
-        {
-            hive::Assert(ptr != nullptr, "Res<T> requires non-null resource pointer");
-        }
+        explicit constexpr Res(const T* ptr) noexcept : ptr_{ptr} {}
 
         [[nodiscard]] constexpr const T& operator*() const noexcept
         {
@@ -131,12 +125,7 @@ namespace queen
         static constexpr TypeId type_id = TypeIdOf<T>();
         static constexpr bool is_mutable = true;
 
-        constexpr ResMut() noexcept : ptr_{nullptr} {}
-
-        explicit constexpr ResMut(T* ptr) noexcept : ptr_{ptr}
-        {
-            hive::Assert(ptr != nullptr, "ResMut<T> requires non-null resource pointer");
-        }
+        explicit constexpr ResMut(T* ptr) noexcept : ptr_{ptr} {}
 
         [[nodiscard]] constexpr T& operator*() const noexcept
         {

--- a/Queen/include/queen/system/system.h
+++ b/Queen/include/queen/system/system.h
@@ -208,16 +208,6 @@ namespace queen
             }
         }
 
-        /**
-         * Execute the system (legacy version without tick tracking)
-         */
-        void Execute(World& world)
-        {
-            if (executor_fn_ != nullptr && enabled_)
-            {
-                executor_fn_(world, user_data_);
-            }
-        }
 
         [[nodiscard]] bool HasExecutor() const noexcept
         {

--- a/Queen/include/queen/system/system_builder.h
+++ b/Queen/include/queen/system/system_builder.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <queen/system/system.h>
+#include <queen/system/system_storage.h>
 #include <queen/system/resource_param.h>
 #include <queen/query/query_term.h>
 #include <queen/query/query.h>
 #include <queen/command/commands.h>
 #include <comb/allocator_concepts.h>
+#include <hive/core/assert.h>
 
 namespace queen
 {
@@ -68,8 +70,53 @@ namespace queen
             InitializeFromTerms();
         }
 
-        // After/Before ordering constraints are handled by the dependency graph
-        // via AccessDescriptor conflict detection. Explicit ordering is not yet implemented.
+        /**
+         * Declare that this system must run after another system
+         *
+         * @param id SystemId of the system to run after
+         */
+        SystemBuilder& After(SystemId id)
+        {
+            descriptor_->AddAfter(id);
+            return *this;
+        }
+
+        /**
+         * Declare that this system must run after another system (by name)
+         *
+         * @param name Name of the system to run after (must already be registered)
+         */
+        SystemBuilder& After(const char* name)
+        {
+            auto* other = storage_->GetSystemByName(name);
+            hive::Assert(other != nullptr, "After(): system not found");
+            descriptor_->AddAfter(other->Id());
+            return *this;
+        }
+
+        /**
+         * Declare that this system must run before another system
+         *
+         * @param id SystemId of the system to run before
+         */
+        SystemBuilder& Before(SystemId id)
+        {
+            descriptor_->AddBefore(id);
+            return *this;
+        }
+
+        /**
+         * Declare that this system must run before another system (by name)
+         *
+         * @param name Name of the system to run before (must already be registered)
+         */
+        SystemBuilder& Before(const char* name)
+        {
+            auto* other = storage_->GetSystemByName(name);
+            hive::Assert(other != nullptr, "Before(): system not found");
+            descriptor_->AddBefore(other->Id());
+            return *this;
+        }
 
         /**
          * Mark system as exclusive (requires exclusive world access)
@@ -278,6 +325,34 @@ namespace queen
             , storage_{&storage}
             , descriptor_{descriptor}
         {
+        }
+
+        SystemBuilder& After(SystemId id)
+        {
+            descriptor_->AddAfter(id);
+            return *this;
+        }
+
+        SystemBuilder& After(const char* name)
+        {
+            auto* other = storage_->GetSystemByName(name);
+            hive::Assert(other != nullptr, "After(): system not found");
+            descriptor_->AddAfter(other->Id());
+            return *this;
+        }
+
+        SystemBuilder& Before(SystemId id)
+        {
+            descriptor_->AddBefore(id);
+            return *this;
+        }
+
+        SystemBuilder& Before(const char* name)
+        {
+            auto* other = storage_->GetSystemByName(name);
+            hive::Assert(other != nullptr, "Before(): system not found");
+            descriptor_->AddBefore(other->Id());
+            return *this;
         }
 
         SystemBuilder& Exclusive()

--- a/Queen/include/queen/system/system_builder.h
+++ b/Queen/include/queen/system/system_builder.h
@@ -68,26 +68,8 @@ namespace queen
             InitializeFromTerms();
         }
 
-        /**
-         * Set the system to run after another system
-         */
-        SystemBuilder& After(SystemId other)
-        {
-            // Store ordering constraint (to be used by scheduler)
-            // For now, just a placeholder - will be implemented with scheduler
-            (void)other;
-            return *this;
-        }
-
-        /**
-         * Set the system to run before another system
-         */
-        SystemBuilder& Before(SystemId other)
-        {
-            // Store ordering constraint (to be used by scheduler)
-            (void)other;
-            return *this;
-        }
+        // After/Before ordering constraints are handled by the dependency graph
+        // via AccessDescriptor conflict detection. Explicit ordering is not yet implemented.
 
         /**
          * Mark system as exclusive (requires exclusive world access)

--- a/Queen/include/queen/system/system_id.h
+++ b/Queen/include/queen/system/system_id.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
 
 namespace queen
 {
@@ -48,7 +47,6 @@ namespace queen
         }
 
         constexpr bool operator==(const SystemId& other) const noexcept = default;
-        constexpr bool operator!=(const SystemId& other) const noexcept = default;
 
         constexpr bool operator<(const SystemId& other) const noexcept
         {
@@ -58,17 +56,5 @@ namespace queen
     private:
         static constexpr uint32_t kInvalidIndex = ~uint32_t{0};
         uint32_t index_;
-    };
-}
-
-namespace std
-{
-    template<>
-    struct hash<queen::SystemId>
-    {
-        size_t operator()(const queen::SystemId& id) const noexcept
-        {
-            return std::hash<uint32_t>{}(id.Index());
-        }
     };
 }

--- a/Queen/include/queen/system/system_storage.h
+++ b/Queen/include/queen/system/system_storage.h
@@ -191,25 +191,20 @@ namespace queen
          * @param world The world to run the system on
          * @param id System to run
          */
-        void RunSystem(World& world, SystemId id)
+        void RunSystem(World& world, SystemId id, Tick current_tick)
         {
             SystemDescriptor<Allocator>* system = GetSystem(id);
             if (system != nullptr)
             {
-                system->Execute(world);
+                system->Execute(world, current_tick);
             }
         }
 
-        /**
-         * Run all registered systems in registration order
-         *
-         * @param world The world to run systems on
-         */
-        void RunAll(World& world)
+        void RunAll(World& world, Tick current_tick)
         {
             for (size_t i = 0; i < systems_.Size(); ++i)
             {
-                systems_[i].Execute(world);
+                systems_[i].Execute(world, current_tick);
             }
         }
 

--- a/Queen/include/queen/world/world.h
+++ b/Queen/include/queen/world/world.h
@@ -286,6 +286,22 @@ namespace queen
             return record->archetype->template HasComponent<T>();
         }
 
+        [[nodiscard]] bool HasComponent(Entity entity, TypeId type_id) const noexcept
+        {
+            if (!IsAlive(entity))
+            {
+                return false;
+            }
+
+            const EntityRecord* record = entity_locations_.Get(entity);
+            if (record == nullptr || record->archetype == nullptr)
+            {
+                return false;
+            }
+
+            return record->archetype->HasComponent(type_id);
+        }
+
         template<typename T>
         void Add(Entity entity, T&& component)
         {
@@ -1644,5 +1660,6 @@ namespace queen
 
 // Include method implementations now that World is complete
 #include <queen/system/system_builder_impl.h>
+#include <queen/observer/observer_storage_impl.h>
 #include <queen/scheduler/scheduler_impl.h>
 #include <queen/scheduler/parallel_scheduler_impl.h>

--- a/Queen/tests/test_mpmc_queue.cpp
+++ b/Queen/tests/test_mpmc_queue.cpp
@@ -1,0 +1,471 @@
+#include <larvae/larvae.h>
+#include <queen/scheduler/mpmc_queue.h>
+#include <comb/linear_allocator.h>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+namespace
+{
+    // ============================================================================
+    // Basic Construction Tests
+    // ============================================================================
+
+    auto test1 = larvae::RegisterTest("QueenMPMCQueue", "Creation", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 16};
+
+        larvae::AssertTrue(queue.IsEmpty());
+        larvae::AssertEqual(queue.Size(), size_t{0});
+        larvae::AssertEqual(queue.Capacity(), size_t{16});
+    });
+
+    auto test2 = larvae::RegisterTest("QueenMPMCQueue", "CapacityRoundsUpToPowerOf2", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+
+        queen::MPMCQueue<int, comb::LinearAllocator> q1{alloc, 3};
+        larvae::AssertEqual(q1.Capacity(), size_t{4});
+
+        queen::MPMCQueue<int, comb::LinearAllocator> q2{alloc, 5};
+        larvae::AssertEqual(q2.Capacity(), size_t{8});
+
+        queen::MPMCQueue<int, comb::LinearAllocator> q3{alloc, 7};
+        larvae::AssertEqual(q3.Capacity(), size_t{8});
+
+        queen::MPMCQueue<int, comb::LinearAllocator> q4{alloc, 8};
+        larvae::AssertEqual(q4.Capacity(), size_t{8});
+
+        queen::MPMCQueue<int, comb::LinearAllocator> q5{alloc, 1};
+        larvae::AssertEqual(q5.Capacity(), size_t{1});
+    });
+
+    // ============================================================================
+    // Single-Thread Push/Pop Tests
+    // ============================================================================
+
+    auto test3 = larvae::RegisterTest("QueenMPMCQueue", "PushAndPopSingle", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 16};
+
+        larvae::AssertTrue(queue.Push(42));
+        larvae::AssertFalse(queue.IsEmpty());
+        larvae::AssertEqual(queue.Size(), size_t{1});
+
+        auto result = queue.Pop();
+        larvae::AssertTrue(result.has_value());
+        larvae::AssertEqual(result.value(), 42);
+        larvae::AssertTrue(queue.IsEmpty());
+    });
+
+    auto test4 = larvae::RegisterTest("QueenMPMCQueue", "PushAndPopMultiple", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 16};
+
+        for (int i = 0; i < 10; ++i)
+        {
+            larvae::AssertTrue(queue.Push(i));
+        }
+
+        larvae::AssertEqual(queue.Size(), size_t{10});
+
+        for (int i = 0; i < 10; ++i)
+        {
+            auto result = queue.Pop();
+            larvae::AssertTrue(result.has_value());
+            larvae::AssertEqual(result.value(), i);
+        }
+
+        larvae::AssertTrue(queue.IsEmpty());
+    });
+
+    auto test5 = larvae::RegisterTest("QueenMPMCQueue", "PopFromEmptyReturnsNullopt", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 8};
+
+        auto result = queue.Pop();
+        larvae::AssertFalse(result.has_value());
+    });
+
+    auto test6 = larvae::RegisterTest("QueenMPMCQueue", "PushToFullReturnsFalse", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 4};
+
+        larvae::AssertTrue(queue.Push(1));
+        larvae::AssertTrue(queue.Push(2));
+        larvae::AssertTrue(queue.Push(3));
+        larvae::AssertTrue(queue.Push(4));
+
+        // Queue is full
+        larvae::AssertFalse(queue.Push(5));
+        larvae::AssertEqual(queue.Size(), size_t{4});
+    });
+
+    auto test7 = larvae::RegisterTest("QueenMPMCQueue", "FIFOOrder", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 8};
+
+        queue.Push(10);
+        queue.Push(20);
+        queue.Push(30);
+
+        larvae::AssertEqual(queue.Pop().value(), 10);
+        larvae::AssertEqual(queue.Pop().value(), 20);
+        larvae::AssertEqual(queue.Pop().value(), 30);
+    });
+
+    auto test8 = larvae::RegisterTest("QueenMPMCQueue", "PushPopCycles", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 4};
+
+        // Fill and drain multiple times to exercise wraparound
+        for (int cycle = 0; cycle < 10; ++cycle)
+        {
+            for (int i = 0; i < 4; ++i)
+            {
+                larvae::AssertTrue(queue.Push(cycle * 4 + i));
+            }
+
+            for (int i = 0; i < 4; ++i)
+            {
+                auto result = queue.Pop();
+                larvae::AssertTrue(result.has_value());
+                larvae::AssertEqual(result.value(), cycle * 4 + i);
+            }
+
+            larvae::AssertTrue(queue.IsEmpty());
+        }
+    });
+
+    auto test9 = larvae::RegisterTest("QueenMPMCQueue", "InterleavedPushPop", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 4};
+
+        queue.Push(1);
+        queue.Push(2);
+        larvae::AssertEqual(queue.Pop().value(), 1);
+
+        queue.Push(3);
+        larvae::AssertEqual(queue.Pop().value(), 2);
+        larvae::AssertEqual(queue.Pop().value(), 3);
+
+        larvae::AssertTrue(queue.IsEmpty());
+    });
+
+    // ============================================================================
+    // Struct Element Tests
+    // ============================================================================
+
+    auto test10 = larvae::RegisterTest("QueenMPMCQueue", "WithStructType", []() {
+        struct Data
+        {
+            int x;
+            float y;
+        };
+
+        comb::LinearAllocator alloc{1024 * 1024};
+        queen::MPMCQueue<Data, comb::LinearAllocator> queue{alloc, 8};
+
+        queue.Push(Data{42, 3.14f});
+        queue.Push(Data{100, 2.71f});
+
+        auto r1 = queue.Pop();
+        larvae::AssertTrue(r1.has_value());
+        larvae::AssertEqual(r1.value().x, 42);
+
+        auto r2 = queue.Pop();
+        larvae::AssertTrue(r2.has_value());
+        larvae::AssertEqual(r2.value().x, 100);
+    });
+
+    // ============================================================================
+    // Multi-Thread Tests
+    // ============================================================================
+
+    auto test11 = larvae::RegisterTest("QueenMPMCQueue", "SingleProducerSingleConsumer", []() {
+        comb::LinearAllocator alloc{4 * 1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 1024};
+
+        constexpr int kCount = 10000;
+        std::atomic<int> sum{0};
+
+        std::thread producer([&queue]() {
+            for (int i = 1; i <= kCount; ++i)
+            {
+                while (!queue.Push(i))
+                {
+                    std::this_thread::yield();
+                }
+            }
+        });
+
+        std::thread consumer([&queue, &sum]() {
+            int consumed = 0;
+            while (consumed < kCount)
+            {
+                if (auto val = queue.Pop())
+                {
+                    sum.fetch_add(val.value(), std::memory_order_relaxed);
+                    ++consumed;
+                }
+                else
+                {
+                    std::this_thread::yield();
+                }
+            }
+        });
+
+        producer.join();
+        consumer.join();
+
+        // Sum of 1..kCount = kCount * (kCount + 1) / 2
+        int expected = kCount * (kCount + 1) / 2;
+        larvae::AssertEqual(sum.load(), expected);
+    });
+
+    auto test12 = larvae::RegisterTest("QueenMPMCQueue", "MultiProducerSingleConsumer", []() {
+        comb::LinearAllocator alloc{4 * 1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 1024};
+
+        constexpr int kProducers = 4;
+        constexpr int kItemsPerProducer = 2500;
+        std::atomic<int> total_consumed{0};
+
+        std::vector<std::thread> producers;
+        for (int p = 0; p < kProducers; ++p)
+        {
+            producers.emplace_back([&queue]() {
+                for (int i = 0; i < kItemsPerProducer; ++i)
+                {
+                    while (!queue.Push(1))
+                    {
+                        std::this_thread::yield();
+                    }
+                }
+            });
+        }
+
+        std::thread consumer([&queue, &total_consumed]() {
+            int target = kProducers * kItemsPerProducer;
+            while (total_consumed.load(std::memory_order_relaxed) < target)
+            {
+                if (auto val = queue.Pop())
+                {
+                    total_consumed.fetch_add(1, std::memory_order_relaxed);
+                }
+                else
+                {
+                    std::this_thread::yield();
+                }
+            }
+        });
+
+        for (auto& t : producers)
+        {
+            t.join();
+        }
+        consumer.join();
+
+        larvae::AssertEqual(total_consumed.load(), kProducers * kItemsPerProducer);
+    });
+
+    auto test13 = larvae::RegisterTest("QueenMPMCQueue", "SingleProducerMultiConsumer", []() {
+        comb::LinearAllocator alloc{4 * 1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 1024};
+
+        constexpr int kTotal = 10000;
+        constexpr int kConsumers = 4;
+        std::atomic<int> total_consumed{0};
+
+        std::thread producer([&queue]() {
+            for (int i = 0; i < kTotal; ++i)
+            {
+                while (!queue.Push(1))
+                {
+                    std::this_thread::yield();
+                }
+            }
+        });
+
+        std::vector<std::thread> consumers;
+        for (int c = 0; c < kConsumers; ++c)
+        {
+            consumers.emplace_back([&queue, &total_consumed]() {
+                while (total_consumed.load(std::memory_order_relaxed) < kTotal)
+                {
+                    if (auto val = queue.Pop())
+                    {
+                        total_consumed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    else
+                    {
+                        std::this_thread::yield();
+                    }
+                }
+            });
+        }
+
+        producer.join();
+        for (auto& t : consumers)
+        {
+            t.join();
+        }
+
+        larvae::AssertEqual(total_consumed.load(), kTotal);
+    });
+
+    auto test14 = larvae::RegisterTest("QueenMPMCQueue", "MultiProducerMultiConsumer", []() {
+        comb::LinearAllocator alloc{4 * 1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 1024};
+
+        constexpr int kProducers = 4;
+        constexpr int kConsumers = 4;
+        constexpr int kItemsPerProducer = 2500;
+        constexpr int kTotalItems = kProducers * kItemsPerProducer;
+
+        std::atomic<int> total_consumed{0};
+
+        std::vector<std::thread> producers;
+        for (int p = 0; p < kProducers; ++p)
+        {
+            producers.emplace_back([&queue]() {
+                for (int i = 0; i < kItemsPerProducer; ++i)
+                {
+                    while (!queue.Push(1))
+                    {
+                        std::this_thread::yield();
+                    }
+                }
+            });
+        }
+
+        std::vector<std::thread> consumers;
+        for (int c = 0; c < kConsumers; ++c)
+        {
+            consumers.emplace_back([&queue, &total_consumed]() {
+                while (total_consumed.load(std::memory_order_relaxed) < kTotalItems)
+                {
+                    if (auto val = queue.Pop())
+                    {
+                        total_consumed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    else
+                    {
+                        std::this_thread::yield();
+                    }
+                }
+            });
+        }
+
+        for (auto& t : producers)
+        {
+            t.join();
+        }
+        for (auto& t : consumers)
+        {
+            t.join();
+        }
+
+        larvae::AssertEqual(total_consumed.load(), kTotalItems);
+    });
+
+    // ============================================================================
+    // Stress Tests
+    // ============================================================================
+
+    auto test15 = larvae::RegisterTest("QueenMPMCQueue", "StressSmallQueue", []() {
+        comb::LinearAllocator alloc{4 * 1024 * 1024};
+        // Small queue forces lots of contention and full/empty transitions
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 4};
+
+        constexpr int kTotal = 10000;
+        std::atomic<int> total_consumed{0};
+
+        std::thread producer([&queue]() {
+            for (int i = 0; i < kTotal; ++i)
+            {
+                while (!queue.Push(i))
+                {
+                    std::this_thread::yield();
+                }
+            }
+        });
+
+        std::thread consumer([&queue, &total_consumed]() {
+            int consumed = 0;
+            while (consumed < kTotal)
+            {
+                if (queue.Pop().has_value())
+                {
+                    ++consumed;
+                }
+                else
+                {
+                    std::this_thread::yield();
+                }
+            }
+            total_consumed.store(consumed, std::memory_order_relaxed);
+        });
+
+        producer.join();
+        consumer.join();
+
+        larvae::AssertEqual(total_consumed.load(), kTotal);
+    });
+
+    auto test16 = larvae::RegisterTest("QueenMPMCQueue", "NoDuplicateOrLostItems", []() {
+        comb::LinearAllocator alloc{4 * 1024 * 1024};
+        queen::MPMCQueue<int, comb::LinearAllocator> queue{alloc, 256};
+
+        constexpr int kProducers = 4;
+        constexpr int kItemsPerProducer = 1000;
+        constexpr int kTotalItems = kProducers * kItemsPerProducer;
+
+        // Each producer pushes unique values, consumers track what they got
+        std::atomic<int> consumed_count{0};
+        std::atomic<int64_t> consumed_sum{0};
+
+        std::vector<std::thread> producers;
+        for (int p = 0; p < kProducers; ++p)
+        {
+            producers.emplace_back([&queue, p]() {
+                int base = p * kItemsPerProducer;
+                for (int i = 0; i < kItemsPerProducer; ++i)
+                {
+                    while (!queue.Push(base + i))
+                    {
+                        std::this_thread::yield();
+                    }
+                }
+            });
+        }
+
+        constexpr int kConsumers = 4;
+        std::vector<std::thread> consumers;
+        for (int c = 0; c < kConsumers; ++c)
+        {
+            consumers.emplace_back([&queue, &consumed_count, &consumed_sum]() {
+                while (consumed_count.load(std::memory_order_relaxed) < kTotalItems)
+                {
+                    if (auto val = queue.Pop())
+                    {
+                        consumed_sum.fetch_add(val.value(), std::memory_order_relaxed);
+                        consumed_count.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    else
+                    {
+                        std::this_thread::yield();
+                    }
+                }
+            });
+        }
+
+        for (auto& t : producers) t.join();
+        for (auto& t : consumers) t.join();
+
+        // Expected sum: sum of 0..kTotalItems-1 = kTotalItems * (kTotalItems - 1) / 2
+        int64_t expected_sum = static_cast<int64_t>(kTotalItems) * (kTotalItems - 1) / 2;
+
+        larvae::AssertEqual(consumed_count.load(), kTotalItems);
+        larvae::AssertEqual(consumed_sum.load(), expected_sum);
+    });
+}

--- a/Queen/tests/test_reflection.cpp
+++ b/Queen/tests/test_reflection.cpp
@@ -95,6 +95,80 @@ namespace
     // Non-reflectable component for testing
     struct TagComponent {};
 
+    // Nested reflectable struct
+    struct Vec2
+    {
+        float x, y;
+
+        static void Reflect(queen::ComponentReflector<>& r)
+        {
+            r.Field("x", &Vec2::x);
+            r.Field("y", &Vec2::y);
+        }
+    };
+
+    // Component containing a nested reflectable struct
+    struct Transform
+    {
+        Vec2 position;
+        Vec2 scale;
+        float rotation;
+
+        static void Reflect(queen::ComponentReflector<>& r)
+        {
+            r.Field("position", &Transform::position);
+            r.Field("scale", &Transform::scale);
+            r.Field("rotation", &Transform::rotation);
+        }
+    };
+
+    // Nested struct containing an Entity field
+    struct TargetInfo
+    {
+        queen::Entity entity;
+        int32_t priority;
+
+        static void Reflect(queen::ComponentReflector<>& r)
+        {
+            r.Field("entity", &TargetInfo::entity);
+            r.Field("priority", &TargetInfo::priority);
+        }
+    };
+
+    // Component with nested struct that has an Entity
+    struct AIComponent
+    {
+        TargetInfo primary_target;
+        TargetInfo secondary_target;
+        float aggro_range;
+
+        static void Reflect(queen::ComponentReflector<>& r)
+        {
+            r.Field("primary_target", &AIComponent::primary_target);
+            r.Field("secondary_target", &AIComponent::secondary_target);
+            r.Field("aggro_range", &AIComponent::aggro_range);
+        }
+    };
+
+    // Non-reflectable nested struct (no Reflect method)
+    struct Color
+    {
+        uint8_t r, g, b, a;
+    };
+
+    // Component containing a non-reflectable nested struct
+    struct Sprite
+    {
+        Color tint;
+        float opacity;
+
+        static void Reflect(queen::ComponentReflector<>& r)
+        {
+            r.Field("tint", &Sprite::tint);
+            r.Field("opacity", &Sprite::opacity);
+        }
+    };
+
     // ============================================================
     // ComponentReflector tests
     // ============================================================
@@ -340,5 +414,182 @@ namespace
         larvae::AssertEqual(loaded.x, 5.0f);
         larvae::AssertEqual(loaded.y, 10.0f);
         larvae::AssertEqual(loaded.z, 15.0f);
+    });
+
+    // ============================================================
+    // Nested struct serialization tests
+    // ============================================================
+
+    auto test19 = larvae::RegisterTest("QueenReflection", "NestedReflectableFieldInfo", []() {
+        queen::ComponentReflector<> reflector;
+        Transform::Reflect(reflector);
+
+        // 3 fields: position (Vec2), scale (Vec2), rotation (float)
+        larvae::AssertEqual(reflector.Count(), size_t{3});
+
+        const auto& pos_field = reflector[0];
+        larvae::AssertEqual(static_cast<int>(pos_field.type), static_cast<int>(queen::FieldType::Struct));
+        larvae::AssertEqual(pos_field.size, sizeof(Vec2));
+        // Nested reflectable should have nested field pointers
+        larvae::AssertNotNull(pos_field.nested_fields);
+        larvae::AssertEqual(pos_field.nested_field_count, size_t{2});
+    });
+
+    auto test20 = larvae::RegisterTest("QueenReflection", "NestedReflectableSerializeRoundtrip", []() {
+        Transform original{};
+        original.position = {1.0f, 2.0f};
+        original.scale = {3.0f, 4.0f};
+        original.rotation = 90.0f;
+
+        comb::LinearAllocator alloc{4096};
+        wax::BinaryWriter<comb::LinearAllocator> writer{alloc};
+
+        queen::Serialize(original, writer);
+
+        Transform loaded{};
+        wax::BinaryReader reader{writer.View()};
+        queen::Deserialize(loaded, reader);
+
+        larvae::AssertEqual(loaded.position.x, 1.0f);
+        larvae::AssertEqual(loaded.position.y, 2.0f);
+        larvae::AssertEqual(loaded.scale.x, 3.0f);
+        larvae::AssertEqual(loaded.scale.y, 4.0f);
+        larvae::AssertEqual(loaded.rotation, 90.0f);
+    });
+
+    auto test21 = larvae::RegisterTest("QueenReflection", "NestedStructWithEntityRoundtrip", []() {
+        AIComponent original{};
+        original.primary_target.entity = queen::Entity{100, 5, queen::Entity::Flags::kAlive};
+        original.primary_target.priority = 10;
+        original.secondary_target.entity = queen::Entity{200, 3, queen::Entity::Flags::kAlive};
+        original.secondary_target.priority = 5;
+        original.aggro_range = 50.0f;
+
+        comb::LinearAllocator alloc{4096};
+        wax::BinaryWriter<comb::LinearAllocator> writer{alloc};
+
+        queen::Serialize(original, writer);
+
+        AIComponent loaded{};
+        wax::BinaryReader reader{writer.View()};
+        queen::Deserialize(loaded, reader);
+
+        // Primary target entity
+        larvae::AssertEqual(loaded.primary_target.entity.Index(), queen::Entity::IndexType{100});
+        larvae::AssertEqual(loaded.primary_target.entity.Generation(), queen::Entity::GenerationType{5});
+        larvae::AssertEqual(loaded.primary_target.priority, int32_t{10});
+        // Secondary target entity
+        larvae::AssertEqual(loaded.secondary_target.entity.Index(), queen::Entity::IndexType{200});
+        larvae::AssertEqual(loaded.secondary_target.entity.Generation(), queen::Entity::GenerationType{3});
+        larvae::AssertEqual(loaded.secondary_target.priority, int32_t{5});
+        // Flat field
+        larvae::AssertEqual(loaded.aggro_range, 50.0f);
+    });
+
+    auto test22 = larvae::RegisterTest("QueenReflection", "NonReflectableNestedStructFallback", []() {
+        // Color has no Reflect() method — serializer should fall back to raw bytes
+        Sprite original{};
+        original.tint = {255, 128, 0, 200};
+        original.opacity = 0.75f;
+
+        comb::LinearAllocator alloc{4096};
+        wax::BinaryWriter<comb::LinearAllocator> writer{alloc};
+
+        queen::Serialize(original, writer);
+
+        Sprite loaded{};
+        wax::BinaryReader reader{writer.View()};
+        queen::Deserialize(loaded, reader);
+
+        larvae::AssertEqual(loaded.tint.r, uint8_t{255});
+        larvae::AssertEqual(loaded.tint.g, uint8_t{128});
+        larvae::AssertEqual(loaded.tint.b, uint8_t{0});
+        larvae::AssertEqual(loaded.tint.a, uint8_t{200});
+        larvae::AssertEqual(loaded.opacity, 0.75f);
+    });
+
+    auto test23 = larvae::RegisterTest("QueenReflection", "NonReflectableNestedFieldInfo", []() {
+        queen::ComponentReflector<> reflector;
+        Sprite::Reflect(reflector);
+
+        const auto& tint_field = reflector[0];
+        larvae::AssertEqual(static_cast<int>(tint_field.type), static_cast<int>(queen::FieldType::Struct));
+        // Non-reflectable nested type should have null nested_fields
+        larvae::AssertNull(tint_field.nested_fields);
+        larvae::AssertEqual(tint_field.nested_field_count, size_t{0});
+    });
+
+    auto test24 = larvae::RegisterTest("QueenReflection", "NestedReflectableViaRegistry", []() {
+        // Test nested struct serialization going through the registry path
+        queen::ComponentRegistry<32> registry;
+        registry.Register<AIComponent>();
+
+        const queen::RegisteredComponent* info = registry.Find(queen::TypeIdOf<AIComponent>());
+        larvae::AssertNotNull(info);
+        larvae::AssertTrue(info->HasReflection());
+
+        AIComponent original{};
+        original.primary_target.entity = queen::Entity{42, 1, queen::Entity::Flags::kAlive};
+        original.primary_target.priority = 99;
+        original.secondary_target.entity = queen::Entity{0, 0, {}};
+        original.secondary_target.priority = 0;
+        original.aggro_range = 25.0f;
+
+        comb::LinearAllocator alloc{4096};
+        wax::BinaryWriter<comb::LinearAllocator> writer{alloc};
+
+        queen::SerializeComponent(&original, info->reflection, writer);
+
+        AIComponent loaded{};
+        wax::BinaryReader reader{writer.View()};
+        queen::DeserializeComponent(&loaded, info->reflection, reader);
+
+        larvae::AssertEqual(loaded.primary_target.entity.Index(), queen::Entity::IndexType{42});
+        larvae::AssertEqual(loaded.primary_target.priority, int32_t{99});
+        larvae::AssertEqual(loaded.aggro_range, 25.0f);
+    });
+
+    // ============================================================
+    // Registry FindByName tests
+    // ============================================================
+
+    auto test25 = larvae::RegisterTest("QueenReflection", "RegistryFindByNameFound", []() {
+        queen::ComponentRegistry<32> registry;
+        registry.Register<Position>();
+        registry.Register<Velocity>();
+        registry.Register<Health>();
+
+        // GetReflectionData returns name from TypeNameOf<T>()
+        auto reflection = queen::GetReflectionData<Position>();
+        const queen::RegisteredComponent* found = registry.FindByName(reflection.name);
+
+        larvae::AssertNotNull(found);
+        larvae::AssertEqual(found->meta.type_id, queen::TypeIdOf<Position>());
+    });
+
+    auto test26 = larvae::RegisterTest("QueenReflection", "RegistryFindByNameNotFound", []() {
+        queen::ComponentRegistry<32> registry;
+        registry.Register<Position>();
+
+        const queen::RegisteredComponent* found = registry.FindByName("NonExistentComponent");
+        larvae::AssertNull(found);
+    });
+
+    auto test27 = larvae::RegisterTest("QueenReflection", "RegistryFindByNameNull", []() {
+        queen::ComponentRegistry<32> registry;
+        registry.Register<Position>();
+
+        const queen::RegisteredComponent* found = registry.FindByName(nullptr);
+        larvae::AssertNull(found);
+    });
+
+    auto test28 = larvae::RegisterTest("QueenReflection", "RegistryFindByNameNoReflection", []() {
+        // RegisterWithoutReflection stores no name, so FindByName shouldn't find it
+        queen::ComponentRegistry<32> registry;
+        registry.RegisterWithoutReflection<TagComponent>();
+
+        // With no reflection data, name is nullptr, so any name search should not crash
+        const queen::RegisteredComponent* found = registry.FindByName("TagComponent");
+        larvae::AssertNull(found);
     });
 }

--- a/Queen/tests/test_regression.cpp
+++ b/Queen/tests/test_regression.cpp
@@ -1,0 +1,421 @@
+#include <larvae/larvae.h>
+#include <queen/core/entity.h>
+#include <queen/core/tick.h>
+#include <queen/core/component_info.h>
+#include <queen/storage/column.h>
+#include <queen/storage/table.h>
+#include <queen/command/command_buffer.h>
+#include <queen/scheduler/work_stealing_deque.h>
+#include <queen/event/events.h>
+#include <queen/world/world.h>
+#include <wax/containers/hash_set.h>
+#include <comb/linear_allocator.h>
+
+namespace
+{
+    // Test components
+    struct Position
+    {
+        float x, y, z;
+    };
+
+    struct Velocity
+    {
+        float dx, dy, dz;
+    };
+
+    struct Health
+    {
+        int current, max;
+    };
+
+    // Component with non-trivial destructor to detect double-destruct
+    struct Tracked
+    {
+        static inline int destruct_count = 0;
+        int value{0};
+        ~Tracked() { ++destruct_count; }
+    };
+
+    // ============================================================================
+    // Regression: Entity hash excludes flags
+    //
+    // Bug: Entity hash previously included flags, causing entities with
+    // same index+generation but different flags to hash differently.
+    // This broke HashSet lookups when flags changed.
+    // ============================================================================
+
+    auto test_entity_hash_1 = larvae::RegisterTest("QueenRegression", "EntityHashExcludesFlags", []() {
+        // Two entities with same index+generation but different flags
+        queen::Entity e1{42, 7, queen::Entity::Flags::kAlive};
+        queen::Entity e2{42, 7, queen::Entity::Flags::kAlive | queen::Entity::Flags::kDisabled};
+        queen::Entity e3{42, 7, queen::Entity::Flags::kNone};
+
+        queen::EntityHash hasher{};
+        size_t h1 = hasher(e1);
+        size_t h2 = hasher(e2);
+        size_t h3 = hasher(e3);
+
+        // Same index+generation must produce same hash regardless of flags
+        larvae::AssertEqual(h1, h2);
+        larvae::AssertEqual(h1, h3);
+    });
+
+    auto test_entity_hash_2 = larvae::RegisterTest("QueenRegression", "EntityEqualityExcludesFlags", []() {
+        // operator== compares only index+generation, NOT flags
+        queen::Entity e1{42, 7, queen::Entity::Flags::kAlive};
+        queen::Entity e2{42, 7, queen::Entity::Flags::kDisabled};
+
+        larvae::AssertTrue(e1 == e2);
+    });
+
+    auto test_entity_hash_3 = larvae::RegisterTest("QueenRegression", "EntityHashSetWithDifferentFlags", []() {
+        comb::LinearAllocator alloc{4096};
+        wax::HashSet<queen::Entity, comb::LinearAllocator> set{alloc, 16};
+
+        queen::Entity e1{42, 7, queen::Entity::Flags::kAlive};
+        queen::Entity e2{42, 7, queen::Entity::Flags::kDisabled};
+
+        set.Insert(e1);
+        set.Insert(e2);
+
+        // Should be treated as the same entity (same index+gen)
+        larvae::AssertEqual(set.Count(), size_t{1});
+        larvae::AssertTrue(set.Contains(e1));
+        larvae::AssertTrue(set.Contains(e2));
+    });
+
+    auto test_entity_hash_4 = larvae::RegisterTest("QueenRegression", "StdHashDelegatesToEntityHash", []() {
+        queen::Entity e1{42, 7, queen::Entity::Flags::kAlive};
+        queen::Entity e2{42, 7, queen::Entity::Flags::kNone};
+
+        std::hash<queen::Entity> std_hasher{};
+        queen::EntityHash queen_hasher{};
+
+        // std::hash must produce same result as EntityHash
+        larvae::AssertEqual(std_hasher(e1), queen_hasher(e1));
+        // And flags should not affect the hash
+        larvae::AssertEqual(std_hasher(e1), std_hasher(e2));
+    });
+
+    // ============================================================================
+    // Regression: Column::SwapRemove properly destructs moved-from source
+    //
+    // Bug: SwapRemove used to move last element into gap but did NOT
+    // destruct the moved-from source, causing resource leaks.
+    // ============================================================================
+
+    auto test_column_swap_remove = larvae::RegisterTest("QueenRegression", "ColumnSwapRemoveDestructsSource", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+
+        Tracked::destruct_count = 0;
+
+        queen::Column<comb::LinearAllocator> column{
+            alloc, queen::ComponentMeta::Of<Tracked>(), 8
+        };
+
+        Tracked t0{10};
+        Tracked t1{20};
+        Tracked t2{30};
+        column.PushCopy(&t0);
+        column.PushCopy(&t1);
+        column.PushCopy(&t2);
+
+        int before_count = Tracked::destruct_count;
+
+        // SwapRemove index 0: moves index 2 into index 0, then destructs old index 2
+        // Should call destruct on the element at index 0 (being overwritten),
+        // then destruct on the moved-from source at index 2
+        column.SwapRemove(0);
+
+        int destructs_during_swap = Tracked::destruct_count - before_count;
+
+        // Should have 2 destructions: dst (old value at index 0) + src (moved-from at index 2)
+        larvae::AssertEqual(destructs_during_swap, 2);
+
+        // Verify the moved element has the correct value
+        larvae::AssertEqual(column.Get<Tracked>(0)->value, 30);
+        larvae::AssertEqual(column.Size(), size_t{2});
+    });
+
+    // ============================================================================
+    // Regression: Table::MoveRowTo transfers ticks
+    //
+    // Bug: MoveRowTo previously did not copy component ticks from source
+    // to destination, losing change detection metadata on archetype transitions.
+    // ============================================================================
+
+    auto test_table_move_ticks = larvae::RegisterTest("QueenRegression", "TableMoveRowToTransfersTicks", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+
+        wax::Vector<queen::ComponentMeta, comb::LinearAllocator> metas1{alloc};
+        metas1.PushBack(queen::ComponentMeta::Of<Position>());
+        metas1.PushBack(queen::ComponentMeta::Of<Velocity>());
+
+        wax::Vector<queen::ComponentMeta, comb::LinearAllocator> metas2{alloc};
+        metas2.PushBack(queen::ComponentMeta::Of<Position>());
+        metas2.PushBack(queen::ComponentMeta::Of<Velocity>());
+        metas2.PushBack(queen::ComponentMeta::Of<Health>());
+
+        queen::Table<comb::LinearAllocator> source{alloc, metas1, 16};
+        queen::Table<comb::LinearAllocator> target{alloc, metas2, 16};
+
+        // Add entity to source with a specific tick
+        queen::Tick add_tick{42};
+        queen::Entity e{1, 0, queen::Entity::Flags::kAlive};
+        uint32_t src_row = source.AllocateRow(e, add_tick);
+
+        // Modify the Position tick
+        queen::Column<comb::LinearAllocator>* pos_col = source.GetColumn<Position>();
+        pos_col->MarkChanged(src_row, queen::Tick{50});
+
+        // Allocate dest row
+        queen::Entity e2{2, 0, queen::Entity::Flags::kAlive};
+        uint32_t dst_row = target.AllocateRow(e2);
+
+        // Move
+        size_t moved = source.MoveRowTo(src_row, target, dst_row);
+        larvae::AssertEqual(moved, size_t{2}); // Position + Velocity
+
+        // Check that ticks were transferred for Position
+        queen::Column<comb::LinearAllocator>* dst_pos = target.GetColumn<Position>();
+        queen::ComponentTicks& ticks = dst_pos->GetTicks(dst_row);
+        larvae::AssertEqual(ticks.added.value, uint32_t{42});
+        larvae::AssertEqual(ticks.changed.value, uint32_t{50});
+    });
+
+    // ============================================================================
+    // Regression: Events uses index-based lookup (not dangling pointers)
+    //
+    // Bug: Events previously stored raw pointers to EventQueue objects.
+    // When new event types were registered, the vector could reallocate,
+    // invalidating those pointers. Now uses index-based lookup.
+    // ============================================================================
+
+    struct EventA { int value; };
+    struct EventB { float value; };
+    struct EventC { int x, y; };
+    struct EventD { int data; };
+
+    auto test_events_realloc = larvae::RegisterTest("QueenRegression", "EventsStableAfterReallocation", []() {
+        comb::LinearAllocator alloc{1024 * 1024};
+        queen::Events<comb::LinearAllocator> events{alloc};
+
+        // Create several event types to potentially trigger internal reallocation
+        events.Send(EventA{1});
+        events.Send(EventB{2.0f});
+        events.Send(EventC{3, 4});
+        events.Send(EventD{5});
+
+        // After multiple queue creations, reading the first type should still work
+        auto reader_a = events.Reader<EventA>();
+        size_t count_a = 0;
+        for (const auto& e : reader_a)
+        {
+            larvae::AssertEqual(e.value, 1);
+            ++count_a;
+        }
+        larvae::AssertEqual(count_a, size_t{1});
+
+        // And writing more to the first type should still work
+        events.Send(EventA{10});
+
+        auto reader_a2 = events.Reader<EventA>();
+        size_t count_a2 = 0;
+        for (const auto& e : reader_a2)
+        {
+            (void)e;
+            ++count_a2;
+        }
+        larvae::AssertEqual(count_a2, size_t{2});
+    });
+
+    // ============================================================================
+    // Regression: CommandBuffer move semantics (was double-free)
+    //
+    // Bug: CommandBuffer move constructor/assignment did not nullify source
+    // block pointers, causing double-free when both source and dest were
+    // destroyed. Now properly nullifies source.
+    // ============================================================================
+
+    auto test_cmdbuf_move = larvae::RegisterTest("QueenRegression", "CommandBufferMoveNullifiesSource", []() {
+        comb::LinearAllocator alloc{65536};
+
+        queen::CommandBuffer<comb::LinearAllocator> cmd1{alloc};
+
+        // Queue some commands to allocate data blocks
+        cmd1.Spawn().With(Position{1.0f, 2.0f, 3.0f});
+        cmd1.Spawn().With(Velocity{4.0f, 5.0f, 6.0f});
+
+        larvae::AssertTrue(cmd1.CommandCount() > 0);
+
+        // Move construct
+        queen::CommandBuffer<comb::LinearAllocator> cmd2{static_cast<queen::CommandBuffer<comb::LinearAllocator>&&>(cmd1)};
+
+        // Source should be empty after move
+        larvae::AssertEqual(cmd1.CommandCount(), size_t{0});
+        larvae::AssertTrue(cmd1.IsEmpty());
+
+        // Destination should have the commands
+        larvae::AssertTrue(cmd2.CommandCount() > 0);
+
+        // Destroying both should not crash (no double-free)
+    });
+
+    auto test_cmdbuf_move_assign = larvae::RegisterTest("QueenRegression", "CommandBufferMoveAssignNullifiesSource", []() {
+        comb::LinearAllocator alloc{65536};
+
+        queen::CommandBuffer<comb::LinearAllocator> cmd1{alloc};
+        queen::CommandBuffer<comb::LinearAllocator> cmd2{alloc};
+
+        cmd1.Spawn().With(Position{1.0f, 2.0f, 3.0f});
+
+        // Move assign
+        cmd2 = static_cast<queen::CommandBuffer<comb::LinearAllocator>&&>(cmd1);
+
+        larvae::AssertEqual(cmd1.CommandCount(), size_t{0});
+        larvae::AssertTrue(cmd2.CommandCount() > 0);
+    });
+
+    // ============================================================================
+    // Regression: WorkStealingDeque retired buffers (was leak)
+    //
+    // Bug: When WorkStealingDeque grows, old buffers were not tracked.
+    // Now uses a RetiredNode linked list to track old buffers for cleanup.
+    // This test verifies growth doesn't crash and all items are preserved.
+    // ============================================================================
+
+    auto test_deque_grow = larvae::RegisterTest("QueenRegression", "WorkStealingDequeGrowPreservesItems", []() {
+        comb::LinearAllocator alloc{4 * 1024 * 1024};
+        queen::WorkStealingDeque<int, comb::LinearAllocator> deque{alloc, 4};
+
+        // Push more items than initial capacity to force Grow()
+        constexpr int kCount = 100;
+        for (int i = 0; i < kCount; ++i)
+        {
+            deque.Push(i);
+        }
+
+        // Pop all and verify no items lost
+        int popped = 0;
+        while (auto val = deque.Pop())
+        {
+            (void)val.value();
+            ++popped;
+        }
+
+        larvae::AssertEqual(popped, kCount);
+    });
+
+    auto test_deque_grow_steal = larvae::RegisterTest("QueenRegression", "WorkStealingDequeGrowWithSteal", []() {
+        comb::LinearAllocator alloc{4 * 1024 * 1024};
+        queen::WorkStealingDeque<int, comb::LinearAllocator> deque{alloc, 4};
+
+        // Push items, steal some, push more (triggers grow with active steals)
+        for (int i = 0; i < 4; ++i)
+        {
+            deque.Push(i);
+        }
+
+        // Steal 2 items
+        auto s1 = deque.Steal();
+        auto s2 = deque.Steal();
+        larvae::AssertTrue(s1.has_value());
+        larvae::AssertTrue(s2.has_value());
+
+        // Push more to trigger grow
+        for (int i = 4; i < 20; ++i)
+        {
+            deque.Push(i);
+        }
+
+        // Count remaining items
+        int count = 0;
+        while (auto val = deque.Pop())
+        {
+            (void)val.value();
+            ++count;
+        }
+
+        // 20 pushed - 2 stolen = 18 remaining
+        larvae::AssertEqual(count, 18);
+    });
+
+    // ============================================================================
+    // Regression: Hierarchy cycle detection + bounded loops
+    //
+    // Bug: SetParent did not check for cycles. Setting child as parent
+    // of its ancestor would create infinite loops in traversal.
+    // Now asserts if cycle would be created.
+    // Also: IsDescendantOf/GetRoot/GetDepth use bounded loops (kMaxHierarchyDepth).
+    // ============================================================================
+
+    auto test_hierarchy_cycle_1 = larvae::RegisterTest("QueenRegression", "IsDescendantOfDetectsChain", []() {
+        queen::World world;
+
+        // Build chain A -> B -> C -> D
+        queen::Entity a = world.Spawn(Position{0.0f, 0.0f, 0.0f});
+        queen::Entity b = world.Spawn(Position{1.0f, 0.0f, 0.0f});
+        queen::Entity c = world.Spawn(Position{2.0f, 0.0f, 0.0f});
+        queen::Entity d = world.Spawn(Position{3.0f, 0.0f, 0.0f});
+
+        world.SetParent(b, a);
+        world.SetParent(c, b);
+        world.SetParent(d, c);
+
+        // D is descendant of A, B, C — but NOT of D itself
+        larvae::AssertTrue(world.IsDescendantOf(d, a));
+        larvae::AssertTrue(world.IsDescendantOf(d, b));
+        larvae::AssertTrue(world.IsDescendantOf(d, c));
+        larvae::AssertFalse(world.IsDescendantOf(d, d));
+
+        // A is not descendant of any of its children
+        larvae::AssertFalse(world.IsDescendantOf(a, b));
+        larvae::AssertFalse(world.IsDescendantOf(a, c));
+        larvae::AssertFalse(world.IsDescendantOf(a, d));
+    });
+
+    auto test_hierarchy_no_cycle = larvae::RegisterTest("QueenRegression", "SetParentDoesNotCreateCycle", []() {
+        queen::World world;
+
+        // Create chain: A -> B -> C
+        queen::Entity a = world.Spawn(Position{0.0f, 0.0f, 0.0f});
+        queen::Entity b = world.Spawn(Position{1.0f, 0.0f, 0.0f});
+        queen::Entity c = world.Spawn(Position{2.0f, 0.0f, 0.0f});
+
+        world.SetParent(b, a);
+        world.SetParent(c, b);
+
+        // Verify the chain
+        larvae::AssertTrue(world.IsDescendantOf(c, a));
+        larvae::AssertTrue(world.IsDescendantOf(b, a));
+        larvae::AssertFalse(world.IsDescendantOf(a, c));
+
+        // GetRoot from any node returns A
+        larvae::AssertTrue(world.GetRoot(c) == a);
+        larvae::AssertTrue(world.GetRoot(b) == a);
+        larvae::AssertTrue(world.GetRoot(a) == a);
+    });
+
+    auto test_hierarchy_bounded_depth = larvae::RegisterTest("QueenRegression", "GetDepthBounded", []() {
+        queen::World world;
+
+        // Build a moderately deep chain to verify bounded traversal works
+        constexpr size_t kDepth = 50;
+        queen::Entity entities[kDepth];
+        entities[0] = world.Spawn(Position{0.0f, 0.0f, 0.0f});
+
+        for (size_t i = 1; i < kDepth; ++i)
+        {
+            entities[i] = world.Spawn(Position{static_cast<float>(i), 0.0f, 0.0f});
+            world.SetParent(entities[i], entities[i - 1]);
+        }
+
+        // Depth should be computed correctly
+        larvae::AssertEqual(world.GetDepth(entities[0]), uint32_t{0});
+        larvae::AssertEqual(world.GetDepth(entities[kDepth - 1]), static_cast<uint32_t>(kDepth - 1));
+
+        // Root traversal from deepest node
+        larvae::AssertTrue(world.GetRoot(entities[kDepth - 1]) == entities[0]);
+    });
+}

--- a/Queen/tests/test_resource_param.cpp
+++ b/Queen/tests/test_resource_param.cpp
@@ -40,7 +40,7 @@ namespace
     });
 
     auto test2 = larvae::RegisterTest("QueenResourceParam", "ResDefaultConstruction", []() {
-        queen::Res<Time> res{};
+        queen::Res<Time> res{nullptr};
 
         larvae::AssertFalse(res.IsValid());
         larvae::AssertNull(res.Get());
@@ -74,7 +74,7 @@ namespace
     auto test7 = larvae::RegisterTest("QueenResourceParam", "ResBoolConversion", []() {
         Time time{1.0f, 0.016f};
         queen::Res<Time> valid_res{&time};
-        queen::Res<Time> invalid_res{};
+        queen::Res<Time> invalid_res{nullptr};
 
         larvae::AssertTrue(static_cast<bool>(valid_res));
         larvae::AssertFalse(static_cast<bool>(invalid_res));
@@ -93,7 +93,7 @@ namespace
     });
 
     auto test9 = larvae::RegisterTest("QueenResourceParam", "ResMutDefaultConstruction", []() {
-        queen::ResMut<Time> res{};
+        queen::ResMut<Time> res{nullptr};
 
         larvae::AssertFalse(res.IsValid());
         larvae::AssertNull(res.Get());

--- a/Queen/tests/test_tick.cpp
+++ b/Queen/tests/test_tick.cpp
@@ -1,0 +1,240 @@
+#include <larvae/larvae.h>
+#include <queen/core/tick.h>
+
+namespace
+{
+    // ============================================================================
+    // Tick Basic Tests
+    // ============================================================================
+
+    auto test1 = larvae::RegisterTest("QueenTick", "DefaultConstruction", []() {
+        queen::Tick tick;
+        larvae::AssertEqual(tick.value, uint32_t{0});
+    });
+
+    auto test2 = larvae::RegisterTest("QueenTick", "ExplicitConstruction", []() {
+        queen::Tick tick{42};
+        larvae::AssertEqual(tick.value, uint32_t{42});
+    });
+
+    auto test3 = larvae::RegisterTest("QueenTick", "Equality", []() {
+        queen::Tick a{10};
+        queen::Tick b{10};
+        queen::Tick c{20};
+
+        larvae::AssertTrue(a == b);
+        larvae::AssertFalse(a != b);
+        larvae::AssertFalse(a == c);
+        larvae::AssertTrue(a != c);
+    });
+
+    auto test4 = larvae::RegisterTest("QueenTick", "PrefixIncrement", []() {
+        queen::Tick tick{5};
+
+        queen::Tick& result = ++tick;
+        larvae::AssertEqual(tick.value, uint32_t{6});
+        larvae::AssertEqual(result.value, uint32_t{6});
+    });
+
+    auto test5 = larvae::RegisterTest("QueenTick", "PostfixIncrement", []() {
+        queen::Tick tick{5};
+
+        queen::Tick old = tick++;
+        larvae::AssertEqual(old.value, uint32_t{5});
+        larvae::AssertEqual(tick.value, uint32_t{6});
+    });
+
+    // ============================================================================
+    // Tick Comparison Tests
+    // ============================================================================
+
+    auto test6 = larvae::RegisterTest("QueenTick", "IsNewerThanBasic", []() {
+        queen::Tick newer{100};
+        queen::Tick older{50};
+
+        larvae::AssertTrue(newer.IsNewerThan(older));
+        larvae::AssertFalse(older.IsNewerThan(newer));
+    });
+
+    auto test7 = larvae::RegisterTest("QueenTick", "IsNewerThanSameIsFalse", []() {
+        queen::Tick a{100};
+        queen::Tick b{100};
+
+        larvae::AssertFalse(a.IsNewerThan(b));
+        larvae::AssertFalse(b.IsNewerThan(a));
+    });
+
+    auto test8 = larvae::RegisterTest("QueenTick", "IsAtLeastBasic", []() {
+        queen::Tick newer{100};
+        queen::Tick older{50};
+        queen::Tick same{100};
+
+        larvae::AssertTrue(newer.IsAtLeast(older));
+        larvae::AssertFalse(older.IsAtLeast(newer));
+        larvae::AssertTrue(newer.IsAtLeast(same));
+    });
+
+    auto test9 = larvae::RegisterTest("QueenTick", "IsNewerThanWraparound", []() {
+        // Test tick wraparound: UINT32_MAX + 1 wraps to 0
+        // If tick A = UINT32_MAX and tick B = UINT32_MAX - 10,
+        // A should be newer than B
+        queen::Tick a{UINT32_MAX};
+        queen::Tick b{UINT32_MAX - 10};
+
+        larvae::AssertTrue(a.IsNewerThan(b));
+        larvae::AssertFalse(b.IsNewerThan(a));
+    });
+
+    auto test10 = larvae::RegisterTest("QueenTick", "IsNewerThanWraparoundAcrossBoundary", []() {
+        // When tick wraps: value 5 is "newer" than UINT32_MAX - 5
+        // because (5 - (UINT32_MAX-5)) = 11 as signed int32 > 0
+        queen::Tick wrapped{5};
+        queen::Tick before_wrap{UINT32_MAX - 5};
+
+        larvae::AssertTrue(wrapped.IsNewerThan(before_wrap));
+        larvae::AssertFalse(before_wrap.IsNewerThan(wrapped));
+    });
+
+    auto test11 = larvae::RegisterTest("QueenTick", "IsAtLeastWraparound", []() {
+        queen::Tick wrapped{5};
+        queen::Tick before_wrap{UINT32_MAX - 5};
+
+        larvae::AssertTrue(wrapped.IsAtLeast(before_wrap));
+        larvae::AssertFalse(before_wrap.IsAtLeast(wrapped));
+    });
+
+    auto test12 = larvae::RegisterTest("QueenTick", "IncrementWrapsAround", []() {
+        queen::Tick tick{UINT32_MAX};
+        ++tick;
+        larvae::AssertEqual(tick.value, uint32_t{0});
+    });
+
+    auto test13 = larvae::RegisterTest("QueenTick", "ConsecutiveIncrements", []() {
+        queen::Tick tick{0};
+        for (uint32_t i = 0; i < 100; ++i)
+        {
+            larvae::AssertEqual(tick.value, i);
+            ++tick;
+        }
+        larvae::AssertEqual(tick.value, uint32_t{100});
+    });
+
+    // ============================================================================
+    // ComponentTicks Tests
+    // ============================================================================
+
+    auto test14 = larvae::RegisterTest("QueenComponentTicks", "DefaultConstruction", []() {
+        queen::ComponentTicks ticks;
+        larvae::AssertEqual(ticks.added.value, uint32_t{0});
+        larvae::AssertEqual(ticks.changed.value, uint32_t{0});
+    });
+
+    auto test15 = larvae::RegisterTest("QueenComponentTicks", "SingleTickConstruction", []() {
+        queen::ComponentTicks ticks{queen::Tick{10}};
+        larvae::AssertEqual(ticks.added.value, uint32_t{10});
+        larvae::AssertEqual(ticks.changed.value, uint32_t{10});
+    });
+
+    auto test16 = larvae::RegisterTest("QueenComponentTicks", "TwoTickConstruction", []() {
+        queen::ComponentTicks ticks{queen::Tick{5}, queen::Tick{10}};
+        larvae::AssertEqual(ticks.added.value, uint32_t{5});
+        larvae::AssertEqual(ticks.changed.value, uint32_t{10});
+    });
+
+    auto test17 = larvae::RegisterTest("QueenComponentTicks", "WasAdded", []() {
+        queen::Tick current{10};
+        queen::ComponentTicks ticks{current};
+
+        // Component was added at tick 10, last_run was tick 5 → was added
+        larvae::AssertTrue(ticks.WasAdded(queen::Tick{5}));
+
+        // Component was added at tick 10, last_run was tick 10 → NOT added (not newer)
+        larvae::AssertFalse(ticks.WasAdded(queen::Tick{10}));
+
+        // Component was added at tick 10, last_run was tick 15 → NOT added
+        larvae::AssertFalse(ticks.WasAdded(queen::Tick{15}));
+    });
+
+    auto test18 = larvae::RegisterTest("QueenComponentTicks", "WasChanged", []() {
+        queen::ComponentTicks ticks{queen::Tick{5}, queen::Tick{10}};
+
+        larvae::AssertTrue(ticks.WasChanged(queen::Tick{8}));
+        larvae::AssertFalse(ticks.WasChanged(queen::Tick{10}));
+        larvae::AssertFalse(ticks.WasChanged(queen::Tick{15}));
+    });
+
+    auto test19 = larvae::RegisterTest("QueenComponentTicks", "WasAddedOrChanged", []() {
+        // Added at tick 5, changed at tick 10
+        queen::ComponentTicks ticks{queen::Tick{5}, queen::Tick{10}};
+
+        // last_run=3: both added and changed are newer
+        larvae::AssertTrue(ticks.WasAddedOrChanged(queen::Tick{3}));
+
+        // last_run=7: added is NOT newer, but changed IS newer
+        larvae::AssertTrue(ticks.WasAddedOrChanged(queen::Tick{7}));
+
+        // last_run=10: neither is newer
+        larvae::AssertFalse(ticks.WasAddedOrChanged(queen::Tick{10}));
+    });
+
+    auto test20 = larvae::RegisterTest("QueenComponentTicks", "MarkChanged", []() {
+        queen::ComponentTicks ticks{queen::Tick{5}};
+        larvae::AssertEqual(ticks.changed.value, uint32_t{5});
+
+        ticks.MarkChanged(queen::Tick{20});
+        larvae::AssertEqual(ticks.changed.value, uint32_t{20});
+        // added should NOT change
+        larvae::AssertEqual(ticks.added.value, uint32_t{5});
+    });
+
+    auto test21 = larvae::RegisterTest("QueenComponentTicks", "SetAdded", []() {
+        queen::ComponentTicks ticks{queen::Tick{5}};
+
+        ticks.SetAdded(queen::Tick{20});
+        larvae::AssertEqual(ticks.added.value, uint32_t{20});
+        larvae::AssertEqual(ticks.changed.value, uint32_t{20});
+    });
+
+    auto test22 = larvae::RegisterTest("QueenComponentTicks", "ChangeDetectionWorkflow", []() {
+        // Simulate a real usage pattern:
+        // 1. Component added at tick 10
+        // 2. System runs at tick 12, detects "added"
+        // 3. Component modified at tick 15
+        // 4. System runs at tick 18, detects "changed" but not "added"
+
+        queen::ComponentTicks ticks{queen::Tick{10}};
+
+        // Step 2: system at tick 12, last_run=9
+        larvae::AssertTrue(ticks.WasAdded(queen::Tick{9}));
+        larvae::AssertTrue(ticks.WasChanged(queen::Tick{9}));
+
+        // Step 3: mark changed at tick 15
+        ticks.MarkChanged(queen::Tick{15});
+
+        // Step 4: system at tick 18, last_run=12
+        larvae::AssertFalse(ticks.WasAdded(queen::Tick{12}));
+        larvae::AssertTrue(ticks.WasChanged(queen::Tick{12}));
+    });
+
+    // ============================================================================
+    // Constexpr Tests
+    // ============================================================================
+
+    auto test23 = larvae::RegisterTest("QueenTick", "ConstexprOperations", []() {
+        // Verify all operations are constexpr-capable
+        constexpr queen::Tick a{10};
+        constexpr queen::Tick b{20};
+
+        constexpr bool newer = b.IsNewerThan(a);
+        larvae::AssertTrue(newer);
+
+        constexpr bool at_least = b.IsAtLeast(a);
+        larvae::AssertTrue(at_least);
+
+        constexpr bool eq = a == a;
+        larvae::AssertTrue(eq);
+
+        constexpr bool neq = a != b;
+        larvae::AssertTrue(neq);
+    });
+}

--- a/Wax/include/wax/containers/hash_map.h
+++ b/Wax/include/wax/containers/hash_map.h
@@ -98,7 +98,6 @@ namespace wax
             }
 
             bool operator==(const Iterator& other) const { return index_ == other.index_; }
-            bool operator!=(const Iterator& other) const { return index_ != other.index_; }
 
             const K& Key() const { return *buckets_[index_].Key(); }
             V& Value() { return *buckets_[index_].Value(); }
@@ -139,7 +138,6 @@ namespace wax
             }
 
             bool operator==(const ConstIterator& other) const { return index_ == other.index_; }
-            bool operator!=(const ConstIterator& other) const { return index_ != other.index_; }
 
             const K& Key() const { return *buckets_[index_].Key(); }
             const V& Value() const { return *buckets_[index_].Value(); }
@@ -608,6 +606,7 @@ namespace wax
 
         static constexpr size_t NextPowerOfTwo(size_t n)
         {
+            if (n == 0) return 1;
             --n;
             n |= n >> 1;
             n |= n >> 2;

--- a/Wax/include/wax/containers/hash_set.h
+++ b/Wax/include/wax/containers/hash_set.h
@@ -65,7 +65,6 @@ namespace wax
             }
 
             bool operator==(const Iterator& other) const { return index_ == other.index_; }
-            bool operator!=(const Iterator& other) const { return index_ != other.index_; }
 
         private:
             void SkipEmpty()
@@ -100,7 +99,6 @@ namespace wax
             }
 
             bool operator==(const ConstIterator& other) const { return index_ == other.index_; }
-            bool operator!=(const ConstIterator& other) const { return index_ != other.index_; }
 
         private:
             void SkipEmpty()
@@ -398,6 +396,7 @@ namespace wax
 
         static constexpr size_t NextPowerOfTwo(size_t n)
         {
+            if (n == 0) return 1;
             --n;
             n |= n >> 1;
             n |= n >> 2;

--- a/Wax/include/wax/containers/string.h
+++ b/Wax/include/wax/containers/string.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <type_traits>
 #include <hive/core/assert.h>
+#include <comb/allocator_concepts.h>
 #include <comb/default_allocator.h>
 #include <wax/containers/string_view.h>
 
@@ -73,7 +74,7 @@ namespace wax
      *   const char* c_str = path.CStr();
      * @endcode
      */
-    template<typename Allocator = comb::DefaultAllocator>
+    template<comb::Allocator Allocator = comb::DefaultAllocator>
     class String
     {
     public:
@@ -746,80 +747,62 @@ namespace wax
     };
 
     // Comparison operators
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] bool operator==(const String<Allocator>& lhs, const String<Allocator>& rhs) noexcept
     {
         return lhs.Equals(rhs);
     }
 
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] bool operator==(const String<Allocator>& lhs, StringView rhs) noexcept
     {
         return lhs.Equals(rhs);
     }
 
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] bool operator==(StringView lhs, const String<Allocator>& rhs) noexcept
     {
         return rhs.Equals(lhs);
     }
 
-    template<typename Allocator>
-    [[nodiscard]] bool operator!=(const String<Allocator>& lhs, const String<Allocator>& rhs) noexcept
-    {
-        return !lhs.Equals(rhs);
-    }
-
-    template<typename Allocator>
-    [[nodiscard]] bool operator!=(const String<Allocator>& lhs, StringView rhs) noexcept
-    {
-        return !lhs.Equals(rhs);
-    }
-
-    template<typename Allocator>
-    [[nodiscard]] bool operator!=(StringView lhs, const String<Allocator>& rhs) noexcept
-    {
-        return !rhs.Equals(lhs);
-    }
-
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] bool operator<(const String<Allocator>& lhs, const String<Allocator>& rhs) noexcept
     {
         return lhs.Compare(rhs) < 0;
     }
 
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] bool operator<(const String<Allocator>& lhs, StringView rhs) noexcept
     {
         return lhs.Compare(rhs) < 0;
     }
 
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] bool operator<(StringView lhs, const String<Allocator>& rhs) noexcept
     {
         return rhs.Compare(lhs) > 0;
     }
 
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] bool operator<=(const String<Allocator>& lhs, const String<Allocator>& rhs) noexcept
     {
         return lhs.Compare(rhs) <= 0;
     }
 
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] bool operator>(const String<Allocator>& lhs, const String<Allocator>& rhs) noexcept
     {
         return lhs.Compare(rhs) > 0;
     }
 
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] bool operator>=(const String<Allocator>& lhs, const String<Allocator>& rhs) noexcept
     {
         return lhs.Compare(rhs) >= 0;
     }
 
     // Concatenation operator
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] String<Allocator> operator+(const String<Allocator>& lhs, const String<Allocator>& rhs)
     {
         String<Allocator> result = lhs;
@@ -827,7 +810,7 @@ namespace wax
         return result;
     }
 
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] String<Allocator> operator+(const String<Allocator>& lhs, StringView rhs)
     {
         String<Allocator> result = lhs;
@@ -835,7 +818,7 @@ namespace wax
         return result;
     }
 
-    template<typename Allocator>
+    template<comb::Allocator Allocator>
     [[nodiscard]] String<Allocator> operator+(const String<Allocator>& lhs, const char* rhs)
     {
         String<Allocator> result = lhs;

--- a/Wax/include/wax/containers/vector.h
+++ b/Wax/include/wax/containers/vector.h
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <initializer_list>
 #include <hive/core/assert.h>
+#include <comb/allocator_concepts.h>
 #include <comb/default_allocator.h>
 
 namespace wax
@@ -53,7 +54,7 @@ namespace wax
      *   }
      * @endcode
      */
-    template<typename T, typename Allocator = comb::DefaultAllocator>
+    template<typename T, comb::Allocator Allocator = comb::DefaultAllocator>
     class Vector
     {
     public:
@@ -343,6 +344,8 @@ namespace wax
             {
                 return;
             }
+
+            hive::Check(new_capacity <= SIZE_MAX / sizeof(T), "Vector capacity overflow");
 
             T* new_data = static_cast<T*>(allocator_->Allocate(new_capacity * sizeof(T), alignof(T)));
             hive::Check(new_data != nullptr, "Vector allocation failed");

--- a/Wax/include/wax/pointers/box.h
+++ b/Wax/include/wax/pointers/box.h
@@ -59,7 +59,7 @@ namespace wax
      *   auto moved = std::move(camera);
      * @endcode
      */
-    template<typename T, typename Allocator = comb::DefaultAllocator>
+    template<typename T, comb::Allocator Allocator = comb::DefaultAllocator>
     class Box
     {
     public:
@@ -162,13 +162,14 @@ namespace wax
             allocator_ = nullptr;
         }
 
-        constexpr void Reset(T* ptr) noexcept
+        constexpr void Reset(Allocator& allocator, T* ptr) noexcept
         {
             if (ptr_ && allocator_)
             {
                 comb::Delete(*allocator_, ptr_);
             }
             ptr_ = ptr;
+            allocator_ = &allocator;
         }
 
         [[nodiscard]] constexpr bool operator==(const Box& other) const noexcept
@@ -176,19 +177,9 @@ namespace wax
             return ptr_ == other.ptr_;
         }
 
-        [[nodiscard]] constexpr bool operator!=(const Box& other) const noexcept
-        {
-            return ptr_ != other.ptr_;
-        }
-
         [[nodiscard]] constexpr bool operator==(std::nullptr_t) const noexcept
         {
             return ptr_ == nullptr;
-        }
-
-        [[nodiscard]] constexpr bool operator!=(std::nullptr_t) const noexcept
-        {
-            return ptr_ != nullptr;
         }
 
     private:
@@ -196,7 +187,7 @@ namespace wax
         Allocator* allocator_;
     };
 
-    template<typename T, typename Allocator, typename... Args>
+    template<typename T, comb::Allocator Allocator, typename... Args>
     [[nodiscard]] Box<T, Allocator> MakeBox(Allocator& allocator, Args&&... args)
     {
         T* ptr = comb::New<T>(allocator, std::forward<Args>(args)...);

--- a/Wax/include/wax/pointers/handle.h
+++ b/Wax/include/wax/pointers/handle.h
@@ -57,11 +57,6 @@ namespace wax
             return index == other.index && generation == other.generation;
         }
 
-        [[nodiscard]] constexpr bool operator!=(const Handle& other) const noexcept
-        {
-            return !(*this == other);
-        }
-
         [[nodiscard]] static constexpr Handle Invalid() noexcept
         {
             return Handle{UINT32_MAX, 0};

--- a/Wax/include/wax/pointers/rc.h
+++ b/Wax/include/wax/pointers/rc.h
@@ -58,7 +58,7 @@ namespace wax
      *   // Object destroyed when last Rc goes out of scope
      * @endcode
      */
-    template<typename T, typename Allocator = comb::DefaultAllocator>
+    template<typename T, comb::Allocator Allocator = comb::DefaultAllocator>
     class Rc
     {
     private:
@@ -76,7 +76,7 @@ namespace wax
         };
 
         // Friend declarations for MakeRc
-        template<typename U, typename A, typename... Args>
+        template<typename U, comb::Allocator A, typename... Args>
         friend Rc<U, A> MakeRc(A& allocator, Args&&... args);
 
         template<typename U, typename... Args>
@@ -226,19 +226,9 @@ namespace wax
             return control_ == other.control_;
         }
 
-        [[nodiscard]] bool operator!=(const Rc& other) const noexcept
-        {
-            return control_ != other.control_;
-        }
-
         [[nodiscard]] bool operator==(std::nullptr_t) const noexcept
         {
             return control_ == nullptr;
-        }
-
-        [[nodiscard]] bool operator!=(std::nullptr_t) const noexcept
-        {
-            return control_ != nullptr;
         }
 
     private:
@@ -264,7 +254,7 @@ namespace wax
     };
 
     // Helper function to create an Rc
-    template<typename T, typename Allocator, typename... Args>
+    template<typename T, comb::Allocator Allocator, typename... Args>
     [[nodiscard]] Rc<T, Allocator> MakeRc(Allocator& allocator, Args&&... args)
     {
         using ControlBlock = typename Rc<T, Allocator>::ControlBlock;

--- a/Wax/include/wax/serialization/binary_reader.h
+++ b/Wax/include/wax/serialization/binary_reader.h
@@ -239,7 +239,7 @@ namespace wax
         {
             uint64_t encoded = ReadVarInt();
             // ZigZag decoding: (n >> 1) ^ -(n & 1)
-            return static_cast<int64_t>((encoded >> 1) ^ (~(encoded & 1) + 1));
+            return static_cast<int64_t>((encoded >> 1) ^ -(encoded & 1));
         }
 
         /**

--- a/Wax/tests/pointers/test_box.cpp
+++ b/Wax/tests/pointers/test_box.cpp
@@ -183,7 +183,7 @@ namespace {
         auto box = wax::MakeBox<int>(alloc, 42);
         int* new_ptr = comb::New<int>(alloc, 99);
 
-        box.Reset(new_ptr);
+        box.Reset(alloc, new_ptr);
 
         larvae::AssertTrue(box.IsValid());
         larvae::AssertEqual(*box, 99);

--- a/Wax/tests/pointers/test_box.cpp
+++ b/Wax/tests/pointers/test_box.cpp
@@ -249,4 +249,31 @@ namespace {
         larvae::AssertTrue(box2 == nullptr);
         larvae::AssertFalse(box2 != nullptr);
     });
+
+    auto test18 = larvae::RegisterTest("WaxBox", "GetAllocator", []() {
+        comb::LinearAllocator alloc{1024};
+
+        auto box = wax::MakeBox<int>(alloc, 42);
+
+        larvae::AssertNotNull(box.GetAllocator());
+        larvae::AssertTrue(box.GetAllocator() == &alloc);
+
+        wax::Box<int, comb::LinearAllocator> null_box;
+        larvae::AssertNull(null_box.GetAllocator());
+    });
+
+    auto test19 = larvae::RegisterTest("WaxBox", "MoveAssignmentDestroysOld", []() {
+        comb::LinearAllocator alloc{1024};
+        TestStruct::destruct_count = 0;
+
+        auto box1 = wax::MakeBox<TestStruct>(alloc, 1, 1.0f);
+        auto box2 = wax::MakeBox<TestStruct>(alloc, 2, 2.0f);
+
+        box2 = std::move(box1);
+
+        // Old box2 value should have been destroyed
+        larvae::AssertEqual(TestStruct::destruct_count, 1);
+        larvae::AssertEqual(box2->value, 1);
+        larvae::AssertTrue(box1.IsNull());
+    });
 }

--- a/Wax/tests/pointers/test_rc.cpp
+++ b/Wax/tests/pointers/test_rc.cpp
@@ -354,4 +354,51 @@ namespace {
 
         larvae::AssertEqual(rc.GetRefCount(), 1u);
     });
+
+    auto test24 = larvae::RegisterTest("WaxRc", "GetAllocator", []() {
+        comb::LinearAllocator alloc{1024};
+
+        auto rc = wax::MakeRc<int>(alloc, 42);
+
+        larvae::AssertNotNull(rc.GetAllocator());
+        larvae::AssertTrue(rc.GetAllocator() == &alloc);
+
+        wax::Rc<int, comb::LinearAllocator> null_rc;
+        larvae::AssertNull(null_rc.GetAllocator());
+    });
+
+    auto test25 = larvae::RegisterTest("WaxRc", "CopyFromNull", []() {
+        wax::Rc<int, comb::LinearAllocator> null_rc;
+
+        wax::Rc<int, comb::LinearAllocator> copy{null_rc};
+
+        larvae::AssertTrue(copy.IsNull());
+        larvae::AssertEqual(copy.GetRefCount(), 0u);
+    });
+
+    auto test26 = larvae::RegisterTest("WaxRc", "CopyAssignNull", []() {
+        comb::LinearAllocator alloc{1024};
+        TestStruct::destruct_count = 0;
+
+        auto rc = wax::MakeRc<TestStruct>(alloc, 10, 3.14f);
+        wax::Rc<TestStruct, comb::LinearAllocator> null_rc;
+
+        rc = null_rc;
+
+        larvae::AssertTrue(rc.IsNull());
+        larvae::AssertEqual(TestStruct::destruct_count, 1);
+    });
+
+    auto test27 = larvae::RegisterTest("WaxRc", "SelfCopyAssignment", []() {
+        comb::LinearAllocator alloc{1024};
+
+        auto rc = wax::MakeRc<int>(alloc, 42);
+
+        auto& ref = rc;
+        rc = ref;
+
+        larvae::AssertTrue(rc.IsValid());
+        larvae::AssertEqual(*rc, 42);
+        larvae::AssertEqual(rc.GetRefCount(), 1u);
+    });
 }

--- a/Wax/tests/test_hash_map.cpp
+++ b/Wax/tests/test_hash_map.cpp
@@ -239,4 +239,89 @@ namespace
         larvae::AssertNotNull(found);
         larvae::AssertEqual(found->value, 100);
     });
+
+    auto test16 = larvae::RegisterTest("WaxHashMap", "MoveAssignment", []() {
+        comb::BuddyAllocator alloc{16384};
+        wax::HashMap<int, int, comb::BuddyAllocator> map1{alloc, 16};
+        wax::HashMap<int, int, comb::BuddyAllocator> map2{alloc, 16};
+
+        map1.Insert(1, 10);
+        map1.Insert(2, 20);
+
+        map2.Insert(100, 1000);
+
+        map2 = static_cast<wax::HashMap<int, int, comb::BuddyAllocator>&&>(map1);
+
+        larvae::AssertEqual(map2.Count(), size_t{2});
+        larvae::AssertNotNull(map2.Find(1));
+        larvae::AssertEqual(*map2.Find(1), 10);
+        larvae::AssertNotNull(map2.Find(2));
+        larvae::AssertEqual(*map2.Find(2), 20);
+        larvae::AssertFalse(map2.Contains(100));
+    });
+
+    auto test17 = larvae::RegisterTest("WaxHashMap", "EmptyMapIteration", []() {
+        comb::LinearAllocator alloc{4096};
+        wax::HashMap<int, int, comb::LinearAllocator> map{alloc, 16};
+
+        int count = 0;
+        for (auto it = map.begin(); it != map.end(); ++it)
+        {
+            ++count;
+        }
+
+        larvae::AssertEqual(count, 0);
+    });
+
+    auto test18 = larvae::RegisterTest("WaxHashMap", "OperatorBracketDefaultConstruct", []() {
+        comb::BuddyAllocator alloc{8192};
+        wax::HashMap<int, int, comb::BuddyAllocator> map{alloc, 16};
+
+        // Access missing key creates default value
+        int& val = map[99];
+        larvae::AssertEqual(val, 0);
+        larvae::AssertEqual(map.Count(), size_t{1});
+        larvae::AssertTrue(map.Contains(99));
+
+        // Modify through reference
+        val = 42;
+        larvae::AssertEqual(map[99], 42);
+    });
+
+    auto test19 = larvae::RegisterTest("WaxHashMap", "ConstFind", []() {
+        comb::LinearAllocator alloc{4096};
+        wax::HashMap<int, int, comb::LinearAllocator> map{alloc, 16};
+
+        map.Insert(1, 10);
+        map.Insert(2, 20);
+
+        const auto& const_map = map;
+
+        const int* found = const_map.Find(1);
+        larvae::AssertNotNull(found);
+        larvae::AssertEqual(*found, 10);
+
+        const int* not_found = const_map.Find(999);
+        larvae::AssertNull(not_found);
+    });
+
+    auto test20 = larvae::RegisterTest("WaxHashMap", "RangeForLoop", []() {
+        comb::LinearAllocator alloc{4096};
+        wax::HashMap<int, int, comb::LinearAllocator> map{alloc, 16};
+
+        map.Insert(1, 10);
+        map.Insert(2, 20);
+        map.Insert(3, 30);
+
+        int sum_keys = 0;
+        int sum_values = 0;
+        for (const auto& [key, value] : map)
+        {
+            sum_keys += key;
+            sum_values += value;
+        }
+
+        larvae::AssertEqual(sum_keys, 6);
+        larvae::AssertEqual(sum_values, 60);
+    });
 }

--- a/Wax/tests/test_hash_map.cpp
+++ b/Wax/tests/test_hash_map.cpp
@@ -153,34 +153,8 @@ namespace
         larvae::AssertEqual(map[42], 200);
     });
 
-    auto test11 = larvae::RegisterTest("WaxHashMap", "StringKeys", []() {
+    auto test11 = larvae::RegisterTest("WaxHashMap", "FloatValues", []() {
         comb::BuddyAllocator alloc{16384};
-
-        struct StringHash
-        {
-            size_t operator()(const char* str) const
-            {
-                size_t hash = 5381;
-                while (*str)
-                {
-                    hash = ((hash << 5) + hash) + static_cast<unsigned char>(*str++);
-                }
-                return hash;
-            }
-        };
-
-        struct StringEqual
-        {
-            bool operator()(const char* a, const char* b) const
-            {
-                while (*a && *b && *a == *b)
-                {
-                    ++a;
-                    ++b;
-                }
-                return *a == *b;
-            }
-        };
 
         wax::HashMap<int, float, comb::BuddyAllocator> map{alloc, 16};
 

--- a/Wax/tests/test_hash_set.cpp
+++ b/Wax/tests/test_hash_set.cpp
@@ -202,4 +202,76 @@ namespace
         float expected = 4.0f / 16.0f;
         larvae::AssertEqual(set.LoadFactor(), expected);
     });
+
+    auto test13 = larvae::RegisterTest("WaxHashSet", "MoveAssignment", []() {
+        comb::BuddyAllocator alloc{16384};
+        wax::HashSet<int, comb::BuddyAllocator> set1{alloc, 16};
+        wax::HashSet<int, comb::BuddyAllocator> set2{alloc, 16};
+
+        set1.Insert(1);
+        set1.Insert(2);
+        set1.Insert(3);
+
+        set2.Insert(100);
+
+        set2 = static_cast<wax::HashSet<int, comb::BuddyAllocator>&&>(set1);
+
+        larvae::AssertEqual(set2.Count(), size_t{3});
+        larvae::AssertTrue(set2.Contains(1));
+        larvae::AssertTrue(set2.Contains(2));
+        larvae::AssertTrue(set2.Contains(3));
+        larvae::AssertFalse(set2.Contains(100));
+    });
+
+    auto test14 = larvae::RegisterTest("WaxHashSet", "EmptySetIteration", []() {
+        comb::LinearAllocator alloc{4096};
+        wax::HashSet<int, comb::LinearAllocator> set{alloc, 16};
+
+        int count = 0;
+        for (auto it = set.begin(); it != set.end(); ++it)
+        {
+            ++count;
+        }
+
+        larvae::AssertEqual(count, 0);
+    });
+
+    auto test15 = larvae::RegisterTest("WaxHashSet", "ConstIteration", []() {
+        comb::LinearAllocator alloc{4096};
+        wax::HashSet<int, comb::LinearAllocator> set{alloc, 16};
+
+        set.Insert(10);
+        set.Insert(20);
+        set.Insert(30);
+
+        const auto& const_set = set;
+
+        int sum = 0;
+        int count = 0;
+        for (auto it = const_set.begin(); it != const_set.end(); ++it)
+        {
+            sum += *it;
+            ++count;
+        }
+
+        larvae::AssertEqual(count, 3);
+        larvae::AssertEqual(sum, 60);
+    });
+
+    auto test16 = larvae::RegisterTest("WaxHashSet", "RangeForLoop", []() {
+        comb::LinearAllocator alloc{4096};
+        wax::HashSet<int, comb::LinearAllocator> set{alloc, 16};
+
+        set.Insert(5);
+        set.Insert(10);
+        set.Insert(15);
+
+        int sum = 0;
+        for (int val : set)
+        {
+            sum += val;
+        }
+
+        larvae::AssertEqual(sum, 30);
+    });
 }


### PR DESCRIPTION
Fixes various bugs found during code audit of Queen, Comb, and Wax modules. Added missing tests to improve coverage.

**Bug fixes:**
- Duplicate `New`/`Delete` in comb (consolidated into `new.h`)
- Missing `BuddyAllocator::Reset()`
- `Box::Reset` signature allowing use-after-free
- `NextPowerOfTwo(0)` not guarded in HashMap/HashSet
- Shutdown crash from LogManager static destruction order
- Observer filters and system ordering issues in Queen
- Reflection serialization for nested structs

**Tests:** 1276 total, 0 failures, 0 warnings